### PR TITLE
fix(trigger): emit custom activity on submit

### DIFF
--- a/nodes/Close/CloseTrigger.node.ts
+++ b/nodes/Close/CloseTrigger.node.ts
@@ -10,6 +10,19 @@ import {
 import { closeApiRequest } from './GenericFunctions';
 import * as crypto from 'crypto';
 
+type CloseWebhookPayload = {
+	event?: unknown;
+	data?: {
+		id?: unknown;
+		status?: unknown;
+		old_status?: unknown;
+		previous_status?: unknown;
+		previous?: {
+			status?: unknown;
+		};
+	} & Record<string, unknown>;
+} & Record<string, unknown>;
+
 function timingSafeEqual(a: Buffer, b: Buffer): boolean {
 	if (a.length !== b.length) {
 		return false;
@@ -59,6 +72,69 @@ function mapAccountSetupAction(action: string): { object_type: string; action: s
 	};
 
 	return mapping[action] || null;
+}
+
+function getStatusValue(value: unknown): string | undefined {
+	if (typeof value !== 'string') {
+		return undefined;
+	}
+
+	return value.trim().toLowerCase();
+}
+
+function getCustomActivityAction(eventName: string): string {
+	const eventParts = eventName.split('.');
+	return eventParts[eventParts.length - 1] || '';
+}
+
+function isCustomActivityEvent(eventName: string): boolean {
+	return eventName.startsWith('activity.custom_activity.');
+}
+
+function getPreviousStatusFromPayload(payload: CloseWebhookPayload): string | undefined {
+	return (
+		getStatusValue(payload.data?.old_status) ??
+		getStatusValue(payload.data?.previous_status) ??
+		getStatusValue(payload.data?.previous?.status)
+	);
+}
+
+export function evaluateCustomActivityWebhook(
+	payload: CloseWebhookPayload,
+	cachedStatus?: string,
+): { shouldEmit: boolean; activityId?: string; currentStatus?: string } {
+	const eventName = typeof payload.event === 'string' ? payload.event : '';
+
+	if (!isCustomActivityEvent(eventName)) {
+		return { shouldEmit: true };
+	}
+
+	const action = getCustomActivityAction(eventName);
+	if (action === 'deleted') {
+		return { shouldEmit: true };
+	}
+
+	const currentStatus = getStatusValue(payload.data?.status);
+	const activityId = typeof payload.data?.id === 'string' ? payload.data.id : undefined;
+
+	if (action === 'created') {
+		return {
+			shouldEmit: currentStatus === 'published',
+			activityId,
+			currentStatus,
+		};
+	}
+
+	if (action === 'updated') {
+		const previousStatus = getPreviousStatusFromPayload(payload) ?? getStatusValue(cachedStatus);
+		return {
+			shouldEmit: previousStatus === 'draft' && currentStatus === 'published',
+			activityId,
+			currentStatus,
+		};
+	}
+
+	return { shouldEmit: false, activityId, currentStatus };
 }
 
 function buildEventsArray(triggerOn: string, actions: string[]): Array<{ object_type: string; action: string }> {
@@ -872,6 +948,27 @@ export class CloseTrigger implements INodeType {
 					this.getNode(),
 					'Webhook signature verification failed - invalid signature',
 				);
+			}
+		}
+
+		const payload = req.body as CloseWebhookPayload;
+		const eventName = typeof payload.event === 'string' ? payload.event : '';
+
+		if (isCustomActivityEvent(eventName)) {
+			const statusByActivityId = (webhookData.customActivityStatusById as Record<string, string>) || {};
+			const activityId = typeof payload.data?.id === 'string' ? payload.data.id : undefined;
+			const cachedStatus = activityId ? statusByActivityId[activityId] : undefined;
+			const evaluation = evaluateCustomActivityWebhook(payload, cachedStatus);
+
+			if (evaluation.activityId && evaluation.currentStatus) {
+				statusByActivityId[evaluation.activityId] = evaluation.currentStatus;
+				webhookData.customActivityStatusById = statusByActivityId;
+			}
+
+			if (!evaluation.shouldEmit) {
+				return {
+					workflowData: [[]],
+				};
 			}
 		}
 

--- a/nodes/Close/WEBHOOK_DOCUMENTATION.md
+++ b/nodes/Close/WEBHOOK_DOCUMENTATION.md
@@ -62,6 +62,13 @@ Track custom activity types you've created in Close CRM.
 - Created: `object_type: "custom_activity"`, `action: "created"`
 - Updated/Deleted: `object_type: "activity.custom_activity"`, `action: "updated|deleted"`
 
+**Submit-Only Trigger Behavior:**
+- Draft autosave and draft edit events are ignored.
+- Trigger emits only when a custom activity is actually submitted:
+  - `created` with `data.status = "published"`
+  - `updated` with a `draft -> published` transition
+- When emitted, the full Close webhook payload is forwarded to the workflow.
+
 ### 3. Contact
 
 Monitor contact records within leads.
@@ -312,6 +319,15 @@ When you deactivate a workflow:
 1. This is expected behavior for Close CRM (they may retry failed webhooks)
 2. Implement idempotency in your workflow using the `event.id` field
 3. Use n8n's built-in deduplication features if available
+
+### Custom Activity Draft Edits Don't Trigger
+
+**Problem**: Custom activity edits in draft mode do not trigger the workflow
+
+**Explanation:**
+1. This trigger intentionally ignores draft autosave and draft edit updates
+2. For custom activities, workflow execution happens on submit (`draft -> published`) only
+3. The full activity payload is available when the submit event is emitted
 
 ### Webhook Registration Failed
 

--- a/nodes/Close/__tests__/CloseTrigger.node.test.ts
+++ b/nodes/Close/__tests__/CloseTrigger.node.test.ts
@@ -1,0 +1,55 @@
+import { evaluateCustomActivityWebhook } from '../CloseTrigger.node';
+
+describe('CloseTrigger custom activity submit filtering', () => {
+	it('suppresses draft update events', () => {
+		const result = evaluateCustomActivityWebhook({
+			event: 'activity.custom_activity.updated',
+			data: {
+				id: 'acti_123',
+				status: 'draft',
+			},
+		});
+
+		expect(result.shouldEmit).toBe(false);
+	});
+
+	it('emits on draft to published transition', () => {
+		const result = evaluateCustomActivityWebhook({
+			event: 'activity.custom_activity.updated',
+			data: {
+				id: 'acti_123',
+				status: 'published',
+				old_status: 'draft',
+			},
+		});
+
+		expect(result.shouldEmit).toBe(true);
+	});
+
+	it('emits for created event already published', () => {
+		const result = evaluateCustomActivityWebhook({
+			event: 'activity.custom_activity.created',
+			data: {
+				id: 'acti_123',
+				status: 'published',
+			},
+		});
+
+		expect(result.shouldEmit).toBe(true);
+	});
+
+	it('suppresses published to published updates', () => {
+		const result = evaluateCustomActivityWebhook(
+			{
+				event: 'activity.custom_activity.updated',
+				data: {
+					id: 'acti_123',
+					status: 'published',
+				},
+			},
+			'published',
+		);
+
+		expect(result.shouldEmit).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary
This fixes Close custom activity trigger behavior to avoid firing during draft autosave/edit events.

The trigger now emits only when a custom activity is actually submitted:
- `created` with `data.status = published`
- `updated` with `draft -> published` transition

It still forwards the full webhook payload when emitted.

## Changes
- Added custom activity submit-only filtering in `CloseTrigger.node.ts`
- Added tests for:
  - draft update blocked
  - draft -> published allowed
  - created published allowed
  - published -> published blocked
- Updated webhook documentation for submit-only behavior

## Why
Close autosaves drafts and emits update events while editing, which caused workflows to trigger too early. This change aligns trigger execution with real submit/publish behavior.