### PR TITLE
fix(trigger): robust custom activity publish handling

### DIFF
--- a/nodes/Close/CloseTrigger.node.ts
+++ b/nodes/Close/CloseTrigger.node.ts
@@ -23,6 +23,14 @@ type CloseWebhookPayload = {
 	} & Record<string, unknown>;
 } & Record<string, unknown>;
 
+type CloseEventObject = {
+	object_type?: unknown;
+	action?: unknown;
+	object_id?: unknown;
+	data?: Record<string, unknown>;
+	previous_data?: Record<string, unknown>;
+} & Record<string, unknown>;
+
 function timingSafeEqual(a: Buffer, b: Buffer): boolean {
 	if (a.length !== b.length) {
 		return false;
@@ -88,7 +96,10 @@ function getCustomActivityAction(eventName: string): string {
 }
 
 function isCustomActivityEvent(eventName: string): boolean {
-	return eventName.startsWith('activity.custom_activity.');
+	return (
+		eventName.startsWith('activity.custom_activity.') ||
+		eventName.startsWith('custom_activity.')
+	);
 }
 
 function getPreviousStatusFromPayload(payload: CloseWebhookPayload): string | undefined {
@@ -99,11 +110,102 @@ function getPreviousStatusFromPayload(payload: CloseWebhookPayload): string | un
 	);
 }
 
+function getEventData(payload: CloseWebhookPayload): Record<string, unknown> | undefined {
+	if (payload.event && typeof payload.event === 'object') {
+		const eventObject = payload.event as CloseEventObject;
+		return eventObject.data;
+	}
+
+	return payload.data as Record<string, unknown> | undefined;
+}
+
+function getEventPreviousData(payload: CloseWebhookPayload): Record<string, unknown> | undefined {
+	if (payload.event && typeof payload.event === 'object') {
+		const eventObject = payload.event as CloseEventObject;
+		return eventObject.previous_data;
+	}
+
+	return undefined;
+}
+
+function getEventObjectId(payload: CloseWebhookPayload): string | undefined {
+	if (payload.event && typeof payload.event === 'object') {
+		const eventObject = payload.event as CloseEventObject;
+		return typeof eventObject.object_id === 'string' ? eventObject.object_id : undefined;
+	}
+
+	return undefined;
+}
+
+function getEventName(payload: CloseWebhookPayload): string {
+	if (typeof payload.event === 'string') {
+		return payload.event;
+	}
+
+	if (payload.event && typeof payload.event === 'object') {
+		const eventObject = payload.event as CloseEventObject;
+		const objectType = typeof eventObject.object_type === 'string' ? eventObject.object_type : '';
+		const action = typeof eventObject.action === 'string' ? eventObject.action : '';
+
+		if (objectType && action) {
+			return `${objectType}.${action}`;
+		}
+	}
+
+	return '';
+}
+
+async function waitForCustomActivityPublished(
+	context: IWebhookFunctions,
+	activityId: string,
+): Promise<boolean> {
+	const maxAttempts = 24;
+	const waitMs = 5000;
+
+	for (let attempt = 0; attempt < maxAttempts; attempt++) {
+		try {
+			const activity = await closeApiRequest.call(
+				context as any,
+				'GET',
+				`/activity/custom/${activityId}/`,
+			);
+			const status = getStatusValue((activity as Record<string, unknown>)?.status);
+			if (status === 'published') {
+				return true;
+			}
+		} catch {
+			// Ignore transient API errors during polling and continue trying.
+		}
+
+		if (attempt < maxAttempts - 1) {
+			await new Promise((resolve) => setTimeout(resolve, waitMs));
+		}
+	}
+
+	return false;
+}
+
+async function fetchCustomActivity(
+	context: IWebhookFunctions,
+	activityId: string,
+): Promise<Record<string, unknown> | null> {
+	try {
+		const activity = await closeApiRequest.call(
+			context as any,
+			'GET',
+			`/activity/custom/${activityId}/`,
+		);
+		return activity as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+}
+
 export function evaluateCustomActivityWebhook(
 	payload: CloseWebhookPayload,
 	cachedStatus?: string,
 ): { shouldEmit: boolean; activityId?: string; currentStatus?: string } {
-	const eventName = typeof payload.event === 'string' ? payload.event : '';
+	const eventName = getEventName(payload);
 
 	if (!isCustomActivityEvent(eventName)) {
 		return { shouldEmit: true };
@@ -114,8 +216,12 @@ export function evaluateCustomActivityWebhook(
 		return { shouldEmit: true };
 	}
 
-	const currentStatus = getStatusValue(payload.data?.status);
-	const activityId = typeof payload.data?.id === 'string' ? payload.data.id : undefined;
+	const eventData = getEventData(payload);
+	const eventPreviousData = getEventPreviousData(payload);
+	const eventObjectId = getEventObjectId(payload);
+
+	const currentStatus = getStatusValue(eventData?.status);
+	const activityId = typeof eventData?.id === 'string' ? eventData.id : eventObjectId;
 
 	if (action === 'created') {
 		return {
@@ -126,7 +232,11 @@ export function evaluateCustomActivityWebhook(
 	}
 
 	if (action === 'updated') {
-		const previousStatus = getPreviousStatusFromPayload(payload) ?? getStatusValue(cachedStatus);
+		const previousStatus = (
+			getStatusValue(eventPreviousData?.status) ??
+			getPreviousStatusFromPayload(payload) ??
+			getStatusValue(cachedStatus)
+		);
 		return {
 			shouldEmit: previousStatus === 'draft' && currentStatus === 'published',
 			activityId,
@@ -952,11 +1062,12 @@ export class CloseTrigger implements INodeType {
 		}
 
 		const payload = req.body as CloseWebhookPayload;
-		const eventName = typeof payload.event === 'string' ? payload.event : '';
+		const eventName = getEventName(payload);
 
 		if (isCustomActivityEvent(eventName)) {
 			const statusByActivityId = (webhookData.customActivityStatusById as Record<string, string>) || {};
-			const activityId = typeof payload.data?.id === 'string' ? payload.data.id : undefined;
+			const eventData = getEventData(payload);
+			const activityId = typeof eventData?.id === 'string' ? eventData.id : undefined;
 			const cachedStatus = activityId ? statusByActivityId[activityId] : undefined;
 			const evaluation = evaluateCustomActivityWebhook(payload, cachedStatus);
 
@@ -966,6 +1077,33 @@ export class CloseTrigger implements INodeType {
 			}
 
 			if (!evaluation.shouldEmit) {
+				// Close may emit a draft update first and skip a dedicated publish update.
+				// Poll the activity status briefly to emit as soon as it is actually submitted.
+				if (evaluation.activityId) {
+					const isNowPublished = await waitForCustomActivityPublished(
+						this,
+						evaluation.activityId,
+					);
+					if (isNowPublished) {
+						const freshActivity = await fetchCustomActivity(this, evaluation.activityId);
+						if (freshActivity) {
+							if (payload.event && typeof payload.event === 'object') {
+								const eventObject = payload.event as CloseEventObject;
+								payload.event = {
+									...eventObject,
+									data: freshActivity,
+								};
+							} else {
+								payload.data = freshActivity as any;
+							}
+						}
+
+						return {
+							workflowData: [this.helpers.returnJsonArray(payload as any)],
+						};
+					}
+				}
+
 				return {
 					workflowData: [[]],
 				};

--- a/nodes/Close/CloseTrigger.node.ts
+++ b/nodes/Close/CloseTrigger.node.ts
@@ -10,6 +10,19 @@ import {
 import { closeApiRequest } from './GenericFunctions';
 import * as crypto from 'crypto';
 
+type CloseWebhookPayload = {
+	event?: unknown;
+	data?: {
+		id?: unknown;
+		status?: unknown;
+		old_status?: unknown;
+		previous_status?: unknown;
+		previous?: {
+			status?: unknown;
+		};
+	} & Record<string, unknown>;
+} & Record<string, unknown>;
+
 function timingSafeEqual(a: Buffer, b: Buffer): boolean {
 	if (a.length !== b.length) {
 		return false;
@@ -59,6 +72,69 @@ function mapAccountSetupAction(action: string): { object_type: string; action: s
 	};
 
 	return mapping[action] || null;
+}
+
+function getStatusValue(value: unknown): string | undefined {
+	if (typeof value !== 'string') {
+		return undefined;
+	}
+
+	return value.trim().toLowerCase();
+}
+
+function getCustomActivityAction(eventName: string): string {
+	const eventParts = eventName.split('.');
+	return eventParts[eventParts.length - 1] || '';
+}
+
+function isCustomActivityEvent(eventName: string): boolean {
+	return eventName.startsWith('activity.custom_activity.');
+}
+
+function getPreviousStatusFromPayload(payload: CloseWebhookPayload): string | undefined {
+	return (
+		getStatusValue(payload.data?.old_status) ??
+		getStatusValue(payload.data?.previous_status) ??
+		getStatusValue(payload.data?.previous?.status)
+	);
+}
+
+export function evaluateCustomActivityWebhook(
+	payload: CloseWebhookPayload,
+	cachedStatus?: string,
+): { shouldEmit: boolean; activityId?: string; currentStatus?: string } {
+	const eventName = typeof payload.event === 'string' ? payload.event : '';
+
+	if (!isCustomActivityEvent(eventName)) {
+		return { shouldEmit: true };
+	}
+
+	const action = getCustomActivityAction(eventName);
+	if (action === 'deleted') {
+		return { shouldEmit: true };
+	}
+
+	const currentStatus = getStatusValue(payload.data?.status);
+	const activityId = typeof payload.data?.id === 'string' ? payload.data.id : undefined;
+
+	if (action === 'created') {
+		return {
+			shouldEmit: currentStatus === 'published',
+			activityId,
+			currentStatus,
+		};
+	}
+
+	if (action === 'updated') {
+		const previousStatus = getPreviousStatusFromPayload(payload) ?? getStatusValue(cachedStatus);
+		return {
+			shouldEmit: previousStatus === 'draft' && currentStatus === 'published',
+			activityId,
+			currentStatus,
+		};
+	}
+
+	return { shouldEmit: false, activityId, currentStatus };
 }
 
 function buildEventsArray(triggerOn: string, actions: string[]): Array<{ object_type: string; action: string }> {
@@ -872,6 +948,27 @@ export class CloseTrigger implements INodeType {
 					this.getNode(),
 					'Webhook signature verification failed - invalid signature',
 				);
+			}
+		}
+
+		const payload = req.body as CloseWebhookPayload;
+		const eventName = typeof payload.event === 'string' ? payload.event : '';
+
+		if (isCustomActivityEvent(eventName)) {
+			const statusByActivityId = (webhookData.customActivityStatusById as Record<string, string>) || {};
+			const activityId = typeof payload.data?.id === 'string' ? payload.data.id : undefined;
+			const cachedStatus = activityId ? statusByActivityId[activityId] : undefined;
+			const evaluation = evaluateCustomActivityWebhook(payload, cachedStatus);
+
+			if (evaluation.activityId && evaluation.currentStatus) {
+				statusByActivityId[evaluation.activityId] = evaluation.currentStatus;
+				webhookData.customActivityStatusById = statusByActivityId;
+			}
+
+			if (!evaluation.shouldEmit) {
+				return {
+					workflowData: [[]],
+				};
 			}
 		}
 

--- a/nodes/Close/WEBHOOK_DOCUMENTATION.md
+++ b/nodes/Close/WEBHOOK_DOCUMENTATION.md
@@ -62,6 +62,13 @@ Track custom activity types you've created in Close CRM.
 - Created: `object_type: "custom_activity"`, `action: "created"`
 - Updated/Deleted: `object_type: "activity.custom_activity"`, `action: "updated|deleted"`
 
+**Submit-Only Trigger Behavior:**
+- Draft autosave and draft edit events are ignored.
+- Trigger emits only when a custom activity is actually submitted:
+  - `created` with `data.status = "published"`
+  - `updated` with a `draft -> published` transition
+- When emitted, the full Close webhook payload is forwarded to the workflow.
+
 ### 3. Contact
 
 Monitor contact records within leads.
@@ -312,6 +319,15 @@ When you deactivate a workflow:
 1. This is expected behavior for Close CRM (they may retry failed webhooks)
 2. Implement idempotency in your workflow using the `event.id` field
 3. Use n8n's built-in deduplication features if available
+
+### Custom Activity Draft Edits Don't Trigger
+
+**Problem**: Custom activity edits in draft mode do not trigger the workflow
+
+**Explanation:**
+1. This trigger intentionally ignores draft autosave and draft edit updates
+2. For custom activities, workflow execution happens on submit (`draft -> published`) only
+3. The full activity payload is available when the submit event is emitted
 
 ### Webhook Registration Failed
 

--- a/nodes/Close/__tests__/CloseTrigger.node.test.ts
+++ b/nodes/Close/__tests__/CloseTrigger.node.test.ts
@@ -1,0 +1,55 @@
+import { evaluateCustomActivityWebhook } from '../CloseTrigger.node';
+
+describe('CloseTrigger custom activity submit filtering', () => {
+	it('suppresses draft update events', () => {
+		const result = evaluateCustomActivityWebhook({
+			event: 'activity.custom_activity.updated',
+			data: {
+				id: 'acti_123',
+				status: 'draft',
+			},
+		});
+
+		expect(result.shouldEmit).toBe(false);
+	});
+
+	it('emits on draft to published transition', () => {
+		const result = evaluateCustomActivityWebhook({
+			event: 'activity.custom_activity.updated',
+			data: {
+				id: 'acti_123',
+				status: 'published',
+				old_status: 'draft',
+			},
+		});
+
+		expect(result.shouldEmit).toBe(true);
+	});
+
+	it('emits for created event already published', () => {
+		const result = evaluateCustomActivityWebhook({
+			event: 'activity.custom_activity.created',
+			data: {
+				id: 'acti_123',
+				status: 'published',
+			},
+		});
+
+		expect(result.shouldEmit).toBe(true);
+	});
+
+	it('suppresses published to published updates', () => {
+		const result = evaluateCustomActivityWebhook(
+			{
+				event: 'activity.custom_activity.updated',
+				data: {
+					id: 'acti_123',
+					status: 'published',
+				},
+			},
+			'published',
+		);
+
+		expect(result.shouldEmit).toBe(false);
+	});
+});

--- a/nodes/Close/__tests__/CloseTrigger.node.test.ts
+++ b/nodes/Close/__tests__/CloseTrigger.node.test.ts
@@ -1,6 +1,24 @@
 import { evaluateCustomActivityWebhook } from '../CloseTrigger.node';
 
 describe('CloseTrigger custom activity submit filtering', () => {
+	it('suppresses draft update events for nested event payload format', () => {
+		const result = evaluateCustomActivityWebhook({
+			event: {
+				object_type: 'activity.custom_activity',
+				action: 'updated',
+				data: {
+					id: 'acti_123',
+					status: 'draft',
+				},
+				previous_data: {
+					status: 'draft',
+				},
+			},
+		});
+
+		expect(result.shouldEmit).toBe(false);
+	});
+
 	it('suppresses draft update events', () => {
 		const result = evaluateCustomActivityWebhook({
 			event: 'activity.custom_activity.updated',
@@ -15,11 +33,16 @@ describe('CloseTrigger custom activity submit filtering', () => {
 
 	it('emits on draft to published transition', () => {
 		const result = evaluateCustomActivityWebhook({
-			event: 'activity.custom_activity.updated',
-			data: {
-				id: 'acti_123',
-				status: 'published',
-				old_status: 'draft',
+			event: {
+				object_type: 'activity.custom_activity',
+				action: 'updated',
+				data: {
+					id: 'acti_123',
+					status: 'published',
+				},
+				previous_data: {
+					status: 'draft',
+				},
 			},
 		});
 
@@ -28,7 +51,7 @@ describe('CloseTrigger custom activity submit filtering', () => {
 
 	it('emits for created event already published', () => {
 		const result = evaluateCustomActivityWebhook({
-			event: 'activity.custom_activity.created',
+			event: 'custom_activity.created',
 			data: {
 				id: 'acti_123',
 				status: 'published',
@@ -49,6 +72,21 @@ describe('CloseTrigger custom activity submit filtering', () => {
 			},
 			'published',
 		);
+
+		expect(result.shouldEmit).toBe(false);
+	});
+
+	it('suppresses custom_activity created draft', () => {
+		const result = evaluateCustomActivityWebhook({
+			event: {
+				object_type: 'activity.custom_activity',
+				action: 'created',
+				data: {
+					id: 'acti_123',
+					status: 'draft',
+				},
+			},
+		});
 
 		expect(result.shouldEmit).toBe(false);
 	});


### PR DESCRIPTION
## Summary
- fix Close custom activity trigger timing so it emits only when publish is confirmed instead of draft autosave edits
- support Close webhook payloads in nested event format (`event.object_type`, `event.action`, `event.data`, `event.previous_data`) and legacy string event format
- fetch and forward fresh custom activity data after publish confirmation so all custom fields are available in trigger output

## Test plan
- [x] Run `npm test -- CloseTrigger.node.test.ts`
- [x] Run `npm run lint -- "nodes/Close/CloseTrigger.node.ts"`
- [x] Manual test in local self-hosted n8n with Close custom activity draft -> publish flow