### PR TITLE
Validate and reactivate Close webhook

### DIFF
--- a/nodes/Close/CloseTrigger.node.ts
+++ b/nodes/Close/CloseTrigger.node.ts
@@ -937,7 +937,22 @@ export class CloseTrigger implements INodeType {
 				}
 
 				try {
-					await closeApiRequest.call(this, 'GET', `/webhook/${webhookData.webhookId}`);
+					const webhook = await closeApiRequest.call(this, 'GET', `/webhook/${webhookData.webhookId}`);
+
+					// If the registered URL no longer matches (e.g. N8N_WEBHOOK_URL changed),
+					// force delete + recreate so Close delivers to the correct endpoint.
+					const currentUrl = this.getNodeWebhookUrl('default');
+					if (webhook.url !== currentUrl) {
+						return false;
+					}
+
+					// Close CRM automatically pauses webhooks after repeated delivery failures
+					// (e.g. during an n8n server restart). Re-activate without recreating so
+					// the webhook ID and signature key remain stable.
+					if (webhook.status === 'paused') {
+						await closeApiRequest.call(this, 'PUT', `/webhook/${webhookData.webhookId}/`, { status: 'active' });
+					}
+
 					return true;
 				} catch {
 					return false;


### PR DESCRIPTION
Fetch the webhook before deciding to keep it. Compare the fetched webhook URL with the node's current webhook URL and return false to force recreate if they differ (handles changes like N8N_WEBHOOK_URL). If Close reports the webhook as 'paused', send a PUT to set status to 'active' so the webhook is reactivated without recreating (preserving webhook ID and signature key).


**User-visible impact**
Users who change N8N_WEBHOOK_URL will have their Close webhook automatically recreated to point at the new URL, instead of silently delivering to a stale endpoint.
Users who restart n8n after a prolonged outage will have their paused Close webhook automatically reactivated no manual intervention in the Close CRM UI required. The webhook ID and signature key remain stable.

**Manual verification**
Changed N8N_WEBHOOK_URL and confirmed n8n triggered a delete + recreate cycle (URL mismatch branch).
Simulated a paused webhook by manually setting status: paused in Close CRM and confirmed the node reactivated it via PUT on the next n8n startup.Summary
Fetch and compare webhook URL before keeping it: The checkExists method now reads the registered webhook URL from Close CRM and compares it to the node's current webhook URL. If they differ (e.g. after an N8N_WEBHOOK_URL environment variable change), false is returned so n8n deletes and recreates the webhook ensuring Close always delivers to the correct endpoint.
Auto-reactivate paused webhooks: Close CRM automatically pauses webhooks after repeated delivery failures (e.g. during an n8n server restart). Instead of recreating the webhook (which would change the webhook ID and signature key), a PUT /webhook/{id}/ call sets status: 'active' so delivery resumes with the same credentials.