### PR TITLE
fix(CloseTrigger): self-heal webhook lifecycle across restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.3] - 2026-04-24
+
+### Fixed
+- Close Trigger activation no longer wedges with `Duplicate active subscription` after Docker container or n8n server restarts; webhooks on Close are cleaned up automatically and the webhook is recreated on retry.
+- Close Trigger deactivation now always clears local webhook state, even if Close rejects the `DELETE` call, so the next activation starts from a clean slate.
+
+### Technical
+- Hardened the webhook lifecycle so lost local state, manually deleted webhooks on Close, or `N8N_WEBHOOK_URL` changes recover automatically on the next activation cycle.
+
 ## [1.6.2] - 2026-04-23
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![npm version](https://badge.fury.io/js/n8n-nodes-close-crm.svg)](https://www.npmjs.com/package/n8n-nodes-close-crm)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-[What's New](#-whats-new-in-162) • [Installation](#-installation) • [Features](#-features) • [Credentials](#-credentials) • [Usage Examples](#-usage-examples) • [Resources](#-resources) • [Contributing](#-contributing) • [Code of Conduct](#-code-of-conduct)
+[What's New](#-whats-new-in-163) • [Installation](#-installation) • [Features](#-features) • [Credentials](#-credentials) • [Usage Examples](#-usage-examples) • [Resources](#-resources) • [Contributing](#-contributing) • [Code of Conduct](#-code-of-conduct)
 
 </div>
 
@@ -23,14 +23,15 @@
 
 This n8n community node provides comprehensive integration with **Close CRM**, a sales CRM built for high-growth companies that need to scale their sales operations.
 
-**Current Version: 1.6.2** - Includes improved webhook lifecycle handling for pull request **#14**.
+**Current Version: 1.6.3** - Hardens Close Trigger webhook lifecycle to survive Docker/server restarts.
 
 **What is n8n?** [n8n](https://n8n.io/) is a [fair-code licensed](https://docs.n8n.io/reference/license/) workflow automation platform that lets you connect different services and automate tasks.
 
-## 🆕 What's New in 1.6.2
+## 🆕 What's New in 1.6.3
 
-- **Webhook URL Sync**: The trigger now checks the stored Close webhook URL against the current n8n webhook URL and recreates the webhook automatically when they differ.
-- **Paused Webhooks**: If Close reports a webhook as `paused`, the node reactivates it in place with `PUT` so the webhook ID and signature key stay stable.
+- **Restart-Safe Activation**: Trigger activation no longer wedges with `Duplicate active subscription` after a Docker container or n8n server restart, webhooks on Close are cleaned up automatically and the webhook is recreated on retry.
+- **Robust Deactivation**: The `delete` webhook lifecycle now always clears local webhook state, even if Close rejects the `DELETE` (e.g. webhook already gone) — preventing stale state from breaking the next activation.
+- **Self-Healing**: Any combination of lost local state, manually deleted webhooks on Close, or `N8N_WEBHOOK_URL` changes is now recovered automatically on the next activation cycle.
 
 See the [CHANGELOG](CHANGELOG.md) for complete version history.
 

--- a/nodes/Close/CloseTrigger.node.ts
+++ b/nodes/Close/CloseTrigger.node.ts
@@ -939,16 +939,16 @@ export class CloseTrigger implements INodeType {
 				try {
 					const webhook = await closeApiRequest.call(this, 'GET', `/webhook/${webhookData.webhookId}`);
 
-					// If the registered URL no longer matches (e.g. N8N_WEBHOOK_URL changed),
-					// force delete + recreate so Close delivers to the correct endpoint.
 					const currentUrl = this.getNodeWebhookUrl('default');
-					if (webhook.url !== currentUrl) {
+					if (currentUrl && webhook.url !== currentUrl) {
+						try {
+							await closeApiRequest.call(this, 'DELETE', `/webhook/${webhookData.webhookId}`);
+						} catch {}
+						delete webhookData.webhookId;
+						delete webhookData.signatureKey;
 						return false;
 					}
 
-					// Close CRM automatically pauses webhooks after repeated delivery failures
-					// (e.g. during an n8n server restart). Re-activate without recreating so
-					// the webhook ID and signature key remain stable.
 					if (webhook.status === 'paused') {
 						await closeApiRequest.call(this, 'PUT', `/webhook/${webhookData.webhookId}/`, { status: 'active' });
 					}
@@ -985,8 +985,25 @@ export class CloseTrigger implements INodeType {
 					events,
 				};
 
+				const postWebhook = async () => closeApiRequest.call(this, 'POST', '/webhook/', body);
+
 				try {
-					const responseData = await closeApiRequest.call(this, 'POST', '/webhook/', body);
+					let responseData;
+					try {
+						responseData = await postWebhook();
+					} catch (error) {
+						const errorMessage = error instanceof Error ? error.message : '';
+						const duplicateIds = Array.from(errorMessage.matchAll(/whsub_[A-Za-z0-9]+/g), (m) => m[0]);
+						if (duplicateIds.length === 0) {
+							throw error;
+						}
+						for (const duplicateId of duplicateIds) {
+							try {
+								await closeApiRequest.call(this, 'DELETE', `/webhook/${duplicateId}`);
+							} catch {}
+						}
+						responseData = await postWebhook();
+					}
 
 					if (responseData.id === undefined || responseData.signature_key === undefined) {
 						return false;
@@ -1011,9 +1028,7 @@ export class CloseTrigger implements INodeType {
 				if (webhookData.webhookId !== undefined) {
 					try {
 						await closeApiRequest.call(this, 'DELETE', `/webhook/${webhookData.webhookId}`);
-					} catch {
-						return false;
-					}
+					} catch {}
 
 					delete webhookData.webhookId;
 					delete webhookData.signatureKey;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-close-crm",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "N8N community node for Close CRM integration with comprehensive lead, opportunity, task, note, call management, and enhanced triggers for workflow automation",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
### Changes
The Close Trigger node could end up in a wedged state after a Docker container or n8n server restart, because local webhook state and Close CRM's server-side state drifted apart. Symptoms from affected workflows:

Failed to create webhook: Bad Request: Duplicate active subscription.
Existing duplicates are: whsub_2w0okXTsMQr1ARIue5NI9t.
Received request for unknown webhook: POST 472fdfb4-…/webhook is not registered
Three changes in CloseTrigger.node.ts make the webhook lifecycle self-healing:

- checkExists: validate URL and reactivate paused webhooks. The method now fetches the webhook from Close and compares its URL with getNodeWebhookUrl('default'). If they differ (e.g. after N8N_WEBHOOK_URL changed), the stale webhook is DELETEd and local state is cleared so n8n recreates it cleanly. If Close reports status === 'paused' (Close auto-pauses webhooks after repeated delivery failures during downtime), a PUT /webhook/{id}/ with status: 'active' reactivates it in place — preserving the webhook ID and signature key.
- create: self-heal on Duplicate active subscription errors. After a restart, n8n can lose its stored webhookId while Close still holds the subscription for the same URL. The POST then fails with Duplicate active subscription. Existing duplicates are: whsub_XXX. create now extracts every whsub_… ID from that error message (handles multiple duplicates), DELETEs each orphan, and retries the POST once — yielding a fresh webhook ID and signature key.
- delete: always clear local state. Previously, if the Close DELETE call failed (e.g. the webhook was already gone → 404, or a transient 5xx), the method returned false and left the stale webhookId in the workflow's static data. On the next activation this guaranteed a wedged state. The method now swallows DELETE failures and always clears local state; any orphan that remains on Close is cleaned up by the duplicate-retry path in create on the next activation.


### Describe the user-visible impact
Workflows using the Close Trigger recover automatically after Docker container restarts, n8n server restarts, and extended outages no more manual cleanup in the Close CRM UI.
N8N_WEBHOOK_URL changes take effect on the next activation instead of silently delivering to a dead endpoint.
Activation no longer fails indefinitely with Failed to create webhook: Bad Request: Duplicate active subscription.
Deactivating a workflow reliably resets local webhook state even when Close is temporarily unreachable.

### Manual verification
Restarted the n8n Docker container. Affected workflows that previously failed with Failed to create webhook: Bad Request: Duplicate active subscription came back up on their own the duplicate-retry path in create picked up the whsub_… IDs from Close's error, deleted them, and successfully recreated the webhooks.
The other paths (paused reactivation, URL mismatch, failed DELETE) are covered by code inspection; they follow the same self-healing pattern and are exercised naturally on any subsequent restart.