### PR TITLE
Add Close CRM automation and bulk actions resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.4] - 2026-04-30
+
+### Added
+- New "Automation & Bulk Actions" resources on the Close CRM node:
+  - **Sequence**: list, get, create, update, delete sequences; subscribe a contact, get / update / list sequence subscriptions (e.g. pause/resume).
+  - **Bulk Action**: create / list / get for bulk Email, bulk Edit (set lead status, set/clear custom field), bulk Delete, and bulk Sequence Subscription (subscribe / pause / resume / resume_finished).
+  - **Export**: start lead exports, start opportunity exports, list exports, fetch a single export to poll `status` and retrieve `download_url`.
+  - **Field Enrichment**: AI-enrich a custom field on a lead or contact via `POST /enrich_field/`.
+- JSON-typed inputs for `s_query`, `schedule`, `steps`, `params`, and `sort` so the full Close advanced filtering / scheduling capability is reachable from n8n.
+- Safety check: bulk delete now requires an `s_query` to avoid accidentally targeting all leads.
+
+### Technical
+- Added `parseJsonParam` helper to validate JSON inputs with clear error messages.
+- 28 new unit tests covering the new endpoints and edge cases (pause/subscribe action types, missing required fields, invalid JSON, list pagination); test count is now 194 across 4 suites.
+- All checks green: `tsc --noEmit`, `eslint`, `jest`, `npm run build`.
+
 ## [1.6.3] - 2026-04-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 [![npm version](https://badge.fury.io/js/n8n-nodes-close-crm.svg)](https://www.npmjs.com/package/n8n-nodes-close-crm)
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-[What's New](#-whats-new-in-163) • [Installation](#-installation) • [Features](#-features) • [Credentials](#-credentials) • [Usage Examples](#-usage-examples) • [Resources](#-resources) • [Contributing](#-contributing) • [Code of Conduct](#-code-of-conduct)
+[What's New](#-whats-new-in-164) • [Installation](#-installation) • [Features](#-features) • [Credentials](#-credentials) • [Usage Examples](#-usage-examples) • [Resources](#-resources) • [Contributing](#-contributing) • [Code of Conduct](#-code-of-conduct)
 
 </div>
 
@@ -23,11 +23,20 @@
 
 This n8n community node provides comprehensive integration with **Close CRM**, a sales CRM built for high-growth companies that need to scale their sales operations.
 
-**Current Version: 1.6.3** - Hardens Close Trigger webhook lifecycle to survive Docker/server restarts.
+**Current Version: 1.6.4** - Adds the new "Automation & Bulk Actions" section: Sequences, Bulk Actions, Exports, and Field Enrichment.
 
 **What is n8n?** [n8n](https://n8n.io/) is a [fair-code licensed](https://docs.n8n.io/reference/license/) workflow automation platform that lets you connect different services and automate tasks.
 
-## 🆕 What's New in 1.6.3
+## 🆕 What's New in 1.6.4
+
+- **Sequences**: List, get, create, update, and delete sequences. Subscribe a contact to a sequence, fetch / list / pause / resume sequence subscriptions.
+- **Bulk Actions**: Send bulk emails, run bulk edits (set lead status, set/clear custom fields with replace/add/remove operations), bulk delete (with required `s_query` safety check), and bulk sequence subscriptions (subscribe / pause / resume / resume_finished). List and fetch endpoints for every bulk action type.
+- **Exports**: Start lead exports (`leads` / `contacts` / `lead_opps`) and opportunity exports in CSV or JSON, with options for date format, fields, smart fields, activities, addresses, and custom objects. List exports and fetch a single export to poll `status` and grab `download_url`.
+- **Field Enrichment**: AI-enrich any custom field on a lead or contact via the new `/enrich_field/` endpoint, with `set_new_value` and `overwrite_existing_value` flags.
+- **Power-User JSON Inputs**: Full Close advanced filtering (`s_query`), schedule definitions, step lists, opportunity export `params`, and sort arrays are accepted as JSON so the complete Close capability is reachable from n8n.
+- **Quality**: 28 new unit tests (194 total across 4 suites). All checks green: `tsc`, `eslint`, `jest`, `npm run build`.
+
+### 🆕 What's New in 1.6.3
 
 - **Restart-Safe Activation**: Trigger activation no longer wedges with `Duplicate active subscription` after a Docker container or n8n server restart, webhooks on Close are cleaned up automatically and the webhook is recreated on retry.
 - **Robust Deactivation**: The `delete` webhook lifecycle now always clears local webhook state, even if Close rejects the `DELETE` (e.g. webhook already gone) — preventing stale state from breaking the next activation.

--- a/README.md
+++ b/README.md
@@ -36,12 +36,6 @@ This n8n community node provides comprehensive integration with **Close CRM**, a
 - **Power-User JSON Inputs**: Full Close advanced filtering (`s_query`), schedule definitions, step lists, opportunity export `params`, and sort arrays are accepted as JSON so the complete Close capability is reachable from n8n.
 - **Quality**: 28 new unit tests (194 total across 4 suites). All checks green: `tsc`, `eslint`, `jest`, `npm run build`.
 
-### 🆕 What's New in 1.6.3
-
-- **Restart-Safe Activation**: Trigger activation no longer wedges with `Duplicate active subscription` after a Docker container or n8n server restart, webhooks on Close are cleaned up automatically and the webhook is recreated on retry.
-- **Robust Deactivation**: The `delete` webhook lifecycle now always clears local webhook state, even if Close rejects the `DELETE` (e.g. webhook already gone) — preventing stale state from breaking the next activation.
-- **Self-Healing**: Any combination of lost local state, manually deleted webhooks on Close, or `N8N_WEBHOOK_URL` changes is now recovered automatically on the next activation cycle.
-
 See the [CHANGELOG](CHANGELOG.md) for complete version history.
 
 ## 🚀 Installation

--- a/nodes/Close/Close.node.ts
+++ b/nodes/Close/Close.node.ts
@@ -36,6 +36,14 @@ import { customActivityFields, customActivityOperations, } from './descriptions/
 
 import { contactFields, contactOperations } from './descriptions/ContactDescription';
 
+import { sequenceFields, sequenceOperations } from './descriptions/SequenceDescription';
+
+import { bulkActionFields, bulkActionOperations } from './descriptions/BulkActionDescription';
+
+import { exportFields, exportOperations } from './descriptions/ExportDescription';
+
+import { fieldEnrichmentFields, fieldEnrichmentOperations } from './descriptions/FieldEnrichmentDescription';
+
 import {
 	constructContactCustomFieldsPayload,
 	constructCustomFieldsPayload,
@@ -57,6 +65,27 @@ function removeNullishValues(payload: JsonObject): JsonObject {
 
 function hasValue(value: unknown): value is Exclude<unknown, null | undefined> {
 	return value !== null && value !== undefined;
+}
+
+function parseJsonParam(value: unknown, fieldName: string): unknown {
+	if (value === undefined || value === null || value === '') {
+		return undefined;
+	}
+	if (typeof value === 'object') {
+		return value;
+	}
+	if (typeof value === 'string') {
+		const trimmed = value.trim();
+		if (!trimmed) {
+			return undefined;
+		}
+		try {
+			return JSON.parse(trimmed);
+		} catch (error) {
+			throw new Error(`Invalid JSON in field "${fieldName}": ${(error as Error).message}`);
+		}
+	}
+	return value;
 }
 
 export class Close implements INodeType {
@@ -134,6 +163,22 @@ export class Close implements INodeType {
 						name: 'Custom Activity',
 						value: 'customActivity',
 					},
+					{
+						name: 'Sequence (Automation & Bulk Actions)',
+						value: 'sequence',
+					},
+					{
+						name: 'Bulk Action (Automation & Bulk Actions)',
+						value: 'bulkAction',
+					},
+					{
+						name: 'Export (Automation & Bulk Actions)',
+						value: 'export',
+					},
+					{
+						name: 'Field Enrichment (Automation & Bulk Actions)',
+						value: 'fieldEnrichment',
+					},
 				],
 				default: 'lead',
 			},
@@ -161,6 +206,14 @@ export class Close implements INodeType {
 			...smsFields,
 			...customActivityOperations,
 			...customActivityFields,
+			...sequenceOperations,
+			...sequenceFields,
+			...bulkActionOperations,
+			...bulkActionFields,
+			...exportOperations,
+			...exportFields,
+			...fieldEnrichmentOperations,
+			...fieldEnrichmentFields,
 			...customFieldsCreateSections,
 			...customFieldsUpdateSections,
 			...customActivityCustomFieldsCreateSections,
@@ -2550,6 +2603,559 @@ export class Close implements INodeType {
 								activity.custom_activity_type_id === customActivityTypeId
 							);
 						}
+					}
+				}
+
+				// =====================================================================
+				// Sequences (Automation & Bulk Actions)
+				// =====================================================================
+				if (resource === 'sequence') {
+					if (operation === 'find') {
+						const returnAll = this.getNodeParameter('returnAll', i) as boolean;
+						if (returnAll) {
+							responseData = await closeApiRequestAllItems.call(
+								this,
+								'data',
+								'GET',
+								'/sequence/',
+								{},
+								qs,
+							);
+						} else {
+							qs._limit = this.getNodeParameter('limit', i);
+							responseData = await closeApiRequest.call(this, 'GET', '/sequence/', {}, qs);
+							responseData = responseData.data;
+						}
+					}
+
+					if (operation === 'get') {
+						const sequenceId = this.getNodeParameter('sequenceId', i) as string;
+						if (!sequenceId) {
+							throw new NodeOperationError(this.getNode(), 'Sequence ID is required');
+						}
+						responseData = await closeApiRequest.call(this, 'GET', `/sequence/${sequenceId}/`);
+					}
+
+					if (operation === 'create') {
+						const name = this.getNodeParameter('name', i) as string;
+						const timezone = this.getNodeParameter('timezone', i, '') as string;
+						const scheduleRaw = this.getNodeParameter('schedule', i, '') as unknown;
+						const stepsRaw = this.getNodeParameter('steps', i, '') as unknown;
+
+						if (!name) {
+							throw new NodeOperationError(this.getNode(), 'Name is required to create a sequence');
+						}
+
+						const body: JsonObject = { name };
+						if (timezone) body.timezone = timezone;
+
+						try {
+							const schedule = parseJsonParam(scheduleRaw, 'Schedule');
+							if (schedule !== undefined) body.schedule = schedule as JsonObject;
+							const steps = parseJsonParam(stepsRaw, 'Steps');
+							if (steps !== undefined) body.steps = steps as JsonObject;
+						} catch (error) {
+							throw new NodeOperationError(this.getNode(), (error as Error).message);
+						}
+
+						responseData = await closeApiRequest.call(this, 'POST', '/sequence/', body);
+					}
+
+					if (operation === 'update') {
+						const sequenceId = this.getNodeParameter('sequenceId', i) as string;
+						const updateFields = this.getNodeParameter('updateFields', i, {}) as JsonObject;
+						if (!sequenceId) {
+							throw new NodeOperationError(this.getNode(), 'Sequence ID is required');
+						}
+
+						const body: JsonObject = {};
+						if (hasValue(updateFields.name) && updateFields.name !== '') body.name = updateFields.name;
+						if (hasValue(updateFields.status) && updateFields.status !== '') body.status = updateFields.status;
+						try {
+							const schedule = parseJsonParam(updateFields.schedule, 'Schedule');
+							if (schedule !== undefined) body.schedule = schedule as JsonObject;
+							const steps = parseJsonParam(updateFields.steps, 'Steps');
+							if (steps !== undefined) body.steps = steps as JsonObject;
+						} catch (error) {
+							throw new NodeOperationError(this.getNode(), (error as Error).message);
+						}
+
+						responseData = await closeApiRequest.call(this, 'PUT', `/sequence/${sequenceId}/`, body);
+					}
+
+					if (operation === 'delete') {
+						const sequenceId = this.getNodeParameter('sequenceId', i) as string;
+						if (!sequenceId) {
+							throw new NodeOperationError(this.getNode(), 'Sequence ID is required');
+						}
+						responseData = await closeApiRequest.call(this, 'DELETE', `/sequence/${sequenceId}/`);
+						if (!responseData || (typeof responseData === 'object' && Object.keys(responseData).length === 0)) {
+							responseData = { success: true, id: sequenceId };
+						}
+					}
+
+					if (operation === 'subscribe') {
+						const sequenceId = this.getNodeParameter('sequenceId', i) as string;
+						const contactId = this.getNodeParameter('contactId', i) as string;
+						const contactEmail = this.getNodeParameter('contactEmail', i) as string;
+						const senderAccountId = this.getNodeParameter('senderAccountId', i) as string;
+						const senderName = this.getNodeParameter('senderName', i) as string;
+						const senderEmail = this.getNodeParameter('senderEmail', i) as string;
+						const additional = this.getNodeParameter('subscribeAdditionalFields', i, {}) as JsonObject;
+
+						if (!sequenceId || !contactId || !contactEmail || !senderAccountId || !senderName || !senderEmail) {
+							throw new NodeOperationError(
+								this.getNode(),
+								'Sequence ID, Contact ID, Contact Email, Sender Account ID, Sender Name, and Sender Email are all required to subscribe a contact',
+							);
+						}
+
+						const body: JsonObject = {
+							sequence_id: sequenceId,
+							contact_id: contactId,
+							contact_email: contactEmail,
+							sender_account_id: senderAccountId,
+							sender_name: senderName,
+							sender_email: senderEmail,
+						};
+
+						if (hasValue(additional.callsAssignedTo) && additional.callsAssignedTo !== '') {
+							body.calls_assigned_to = (additional.callsAssignedTo as string)
+								.split(',')
+								.map((id) => id.trim())
+								.filter(Boolean);
+						}
+
+						responseData = await closeApiRequest.call(this, 'POST', '/sequence_subscription/', body);
+					}
+
+					if (operation === 'getSubscription') {
+						const subscriptionId = this.getNodeParameter('subscriptionId', i) as string;
+						if (!subscriptionId) {
+							throw new NodeOperationError(this.getNode(), 'Subscription ID is required');
+						}
+						responseData = await closeApiRequest.call(
+							this,
+							'GET',
+							`/sequence_subscription/${subscriptionId}/`,
+						);
+					}
+
+					if (operation === 'updateSubscription') {
+						const subscriptionId = this.getNodeParameter('subscriptionId', i) as string;
+						const status = this.getNodeParameter('subscriptionStatus', i) as string;
+						if (!subscriptionId) {
+							throw new NodeOperationError(this.getNode(), 'Subscription ID is required');
+						}
+						responseData = await closeApiRequest.call(
+							this,
+							'PUT',
+							`/sequence_subscription/${subscriptionId}/`,
+							{ status },
+						);
+					}
+
+					if (operation === 'findSubscriptions') {
+						const filters = this.getNodeParameter('subscriptionFilters', i, {}) as JsonObject;
+						const returnAll = this.getNodeParameter('returnAll', i) as boolean;
+
+						if (!filters.sequenceId && !filters.contactId && !filters.leadId) {
+							throw new NodeOperationError(
+								this.getNode(),
+								'At least one of Sequence ID, Contact ID, or Lead ID is required to list subscriptions',
+							);
+						}
+
+						if (filters.sequenceId) qs.sequence_id = filters.sequenceId;
+						if (filters.contactId) qs.contact_id = filters.contactId;
+						if (filters.leadId) qs.lead_id = filters.leadId;
+
+						if (returnAll) {
+							responseData = await closeApiRequestAllItems.call(
+								this,
+								'data',
+								'GET',
+								'/sequence_subscription/',
+								{},
+								qs,
+							);
+						} else {
+							qs._limit = this.getNodeParameter('limit', i);
+							responseData = await closeApiRequest.call(
+								this,
+								'GET',
+								'/sequence_subscription/',
+								{},
+								qs,
+							);
+							responseData = responseData.data;
+						}
+					}
+				}
+
+				// =====================================================================
+				// Bulk Actions (Automation & Bulk Actions)
+				// =====================================================================
+				if (resource === 'bulkAction') {
+					const applyCommonBulkOptions = (
+						body: JsonObject,
+						additional: JsonObject,
+						fieldLabel: string,
+					): void => {
+						if (hasValue(additional.sendDoneEmail)) {
+							body.send_done_email = additional.sendDoneEmail;
+						}
+						if (hasValue(additional.resultsLimit) && additional.resultsLimit !== 0) {
+							body.results_limit = additional.resultsLimit;
+						}
+						const sort = parseJsonParam(additional.sort, `${fieldLabel} > Sort`);
+						if (sort !== undefined) body.sort = sort as JsonObject;
+					};
+
+					const listBulk = async (endpoint: string): Promise<unknown> => {
+						const returnAll = this.getNodeParameter('returnAll', i) as boolean;
+						if (returnAll) {
+							return closeApiRequestAllItems.call(this, 'data', 'GET', endpoint, {}, qs);
+						}
+						qs._limit = this.getNodeParameter('limit', i);
+						const data = await closeApiRequest.call(this, 'GET', endpoint, {}, qs);
+						return data.data;
+					};
+
+					if (operation === 'createEmail') {
+						const templateId = this.getNodeParameter('templateId', i) as string;
+						const emailAccountId = this.getNodeParameter('emailAccountId', i) as string;
+						const contactPreference = this.getNodeParameter('contactPreference', i) as string;
+						const sQueryRaw = this.getNodeParameter('sQuery', i, '') as unknown;
+						const additional = this.getNodeParameter('emailAdditionalFields', i, {}) as JsonObject;
+
+						if (!templateId || !emailAccountId) {
+							throw new NodeOperationError(
+								this.getNode(),
+								'Template ID and Email Account ID are required to send a bulk email',
+							);
+						}
+
+						const body: JsonObject = {
+							template_id: templateId,
+							email_account_id: emailAccountId,
+							contact_preference: contactPreference,
+						};
+
+						try {
+							const sQuery = parseJsonParam(sQueryRaw, 'Search Query');
+							if (sQuery !== undefined) body.s_query = sQuery as JsonObject;
+						} catch (error) {
+							throw new NodeOperationError(this.getNode(), (error as Error).message);
+						}
+
+						if (hasValue(additional.sender) && additional.sender !== '') body.sender = additional.sender;
+						applyCommonBulkOptions(body, additional, 'Email Additional Fields');
+
+						responseData = await closeApiRequest.call(this, 'POST', '/bulk_action/email/', body);
+					}
+
+					if (operation === 'listEmail') {
+						responseData = await listBulk('/bulk_action/email/');
+					}
+
+					if (operation === 'getEmail') {
+						const id = this.getNodeParameter('bulkActionId', i) as string;
+						if (!id) throw new NodeOperationError(this.getNode(), 'Bulk Action ID is required');
+						responseData = await closeApiRequest.call(this, 'GET', `/bulk_action/email/${id}/`);
+					}
+
+					if (operation === 'createEdit') {
+						const editType = this.getNodeParameter('editType', i) as string;
+						const body: JsonObject = { type: editType };
+
+						if (editType === 'set_lead_status') {
+							const leadStatusId = this.getNodeParameter('leadStatusId', i) as string;
+							if (!leadStatusId) {
+								throw new NodeOperationError(
+									this.getNode(),
+									'Lead Status is required for "Set Lead Status" bulk edit',
+								);
+							}
+							body.lead_status_id = leadStatusId;
+						} else if (editType === 'set_custom_field' || editType === 'clear_custom_field') {
+							const customFieldId = this.getNodeParameter('customFieldId', i) as string;
+							if (!customFieldId) {
+								throw new NodeOperationError(
+									this.getNode(),
+									'Custom Field ID is required for custom field bulk edits',
+								);
+							}
+							body.custom_field_id = customFieldId;
+
+							if (editType === 'set_custom_field') {
+								const customFieldValue = this.getNodeParameter('customFieldValue', i, '') as string;
+								const customFieldOperation = this.getNodeParameter(
+									'customFieldOperation',
+									i,
+									'replace',
+								) as string;
+								body.custom_field_value = customFieldValue;
+								body.custom_field_operation = customFieldOperation;
+							}
+						}
+
+						const sQueryRaw = this.getNodeParameter('sQuery', i, '') as unknown;
+						const additional = this.getNodeParameter('editAdditionalFields', i, {}) as JsonObject;
+
+						try {
+							const sQuery = parseJsonParam(sQueryRaw, 'Search Query');
+							if (sQuery !== undefined) body.s_query = sQuery as JsonObject;
+						} catch (error) {
+							throw new NodeOperationError(this.getNode(), (error as Error).message);
+						}
+
+						applyCommonBulkOptions(body, additional, 'Edit Additional Fields');
+
+						responseData = await closeApiRequest.call(this, 'POST', '/bulk_action/edit/', body);
+					}
+
+					if (operation === 'listEdit') {
+						responseData = await listBulk('/bulk_action/edit/');
+					}
+
+					if (operation === 'getEdit') {
+						const id = this.getNodeParameter('bulkActionId', i) as string;
+						if (!id) throw new NodeOperationError(this.getNode(), 'Bulk Action ID is required');
+						responseData = await closeApiRequest.call(this, 'GET', `/bulk_action/edit/${id}/`);
+					}
+
+					if (operation === 'createDelete') {
+						const sQueryRaw = this.getNodeParameter('sQuery', i, '') as unknown;
+						const additional = this.getNodeParameter('deleteAdditionalFields', i, {}) as JsonObject;
+
+						const body: JsonObject = {};
+						try {
+							const sQuery = parseJsonParam(sQueryRaw, 'Search Query');
+							if (sQuery !== undefined) body.s_query = sQuery as JsonObject;
+						} catch (error) {
+							throw new NodeOperationError(this.getNode(), (error as Error).message);
+						}
+
+						if (!body.s_query) {
+							throw new NodeOperationError(
+								this.getNode(),
+								'Search Query (s_query) is required for bulk delete to avoid deleting all leads',
+							);
+						}
+
+						applyCommonBulkOptions(body, additional, 'Delete Additional Fields');
+
+						responseData = await closeApiRequest.call(this, 'POST', '/bulk_action/delete/', body);
+					}
+
+					if (operation === 'listDelete') {
+						responseData = await listBulk('/bulk_action/delete/');
+					}
+
+					if (operation === 'getDelete') {
+						const id = this.getNodeParameter('bulkActionId', i) as string;
+						if (!id) throw new NodeOperationError(this.getNode(), 'Bulk Action ID is required');
+						responseData = await closeApiRequest.call(this, 'GET', `/bulk_action/delete/${id}/`);
+					}
+
+					if (operation === 'createSequenceSubscription') {
+						const actionType = this.getNodeParameter('sequenceActionType', i) as string;
+						const body: JsonObject = { action_type: actionType };
+
+						if (actionType === 'subscribe') {
+							const sequenceId = this.getNodeParameter('sequenceId', i) as string;
+							const senderAccountId = this.getNodeParameter('senderAccountId', i) as string;
+							const senderName = this.getNodeParameter('senderName', i) as string;
+							const senderEmail = this.getNodeParameter('senderEmail', i) as string;
+							const contactPreference = this.getNodeParameter('contactPreference', i) as string;
+							if (!sequenceId || !senderAccountId || !senderName || !senderEmail) {
+								throw new NodeOperationError(
+									this.getNode(),
+									'Sequence ID, Sender Account ID, Sender Name, and Sender Email are required to subscribe in bulk',
+								);
+							}
+							body.sequence_id = sequenceId;
+							body.sender_account_id = senderAccountId;
+							body.sender_name = senderName;
+							body.sender_email = senderEmail;
+							body.contact_preference = contactPreference;
+						}
+
+						const sQueryRaw = this.getNodeParameter('sQuery', i, '') as unknown;
+						const additional = this.getNodeParameter(
+							'sequenceSubscriptionAdditionalFields',
+							i,
+							{},
+						) as JsonObject;
+
+						try {
+							const sQuery = parseJsonParam(sQueryRaw, 'Search Query');
+							if (sQuery !== undefined) body.s_query = sQuery as JsonObject;
+						} catch (error) {
+							throw new NodeOperationError(this.getNode(), (error as Error).message);
+						}
+
+						applyCommonBulkOptions(body, additional, 'Sequence Subscription Additional Fields');
+
+						responseData = await closeApiRequest.call(
+							this,
+							'POST',
+							'/bulk_action/sequence_subscription/',
+							body,
+						);
+					}
+
+					if (operation === 'listSequenceSubscription') {
+						responseData = await listBulk('/bulk_action/sequence_subscription/');
+					}
+
+					if (operation === 'getSequenceSubscription') {
+						const id = this.getNodeParameter('bulkActionId', i) as string;
+						if (!id) throw new NodeOperationError(this.getNode(), 'Bulk Action ID is required');
+						responseData = await closeApiRequest.call(
+							this,
+							'GET',
+							`/bulk_action/sequence_subscription/${id}/`,
+						);
+					}
+				}
+
+				// =====================================================================
+				// Exports (Automation & Bulk Actions)
+				// =====================================================================
+				if (resource === 'export') {
+					const applyExportOptions = (body: JsonObject, additional: JsonObject): void => {
+						if (hasValue(additional.dateFormat) && additional.dateFormat !== '') {
+							body.date_format = additional.dateFormat;
+						}
+						if (hasValue(additional.fields) && additional.fields !== '') {
+							body.fields = (additional.fields as string)
+								.split(',')
+								.map((f) => f.trim())
+								.filter(Boolean);
+						}
+						if (hasValue(additional.includeActivities)) {
+							body.include_activities = additional.includeActivities;
+						}
+						if (hasValue(additional.includeSmartFields)) {
+							body.include_smart_fields = additional.includeSmartFields;
+						}
+						if (hasValue(additional.includeAddresses)) {
+							body.include_addresses = additional.includeAddresses;
+						}
+						if (hasValue(additional.includeCustomObjects)) {
+							body.include_custom_objects = additional.includeCustomObjects;
+						}
+						if (hasValue(additional.sendDoneEmail)) {
+							body.send_done_email = additional.sendDoneEmail;
+						}
+						if (hasValue(additional.resultsLimit) && additional.resultsLimit !== 0) {
+							body.results_limit = additional.resultsLimit;
+						}
+					};
+
+					if (operation === 'find') {
+						const returnAll = this.getNodeParameter('returnAll', i) as boolean;
+						if (returnAll) {
+							responseData = await closeApiRequestAllItems.call(
+								this,
+								'data',
+								'GET',
+								'/export/',
+								{},
+								qs,
+							);
+						} else {
+							qs._limit = this.getNodeParameter('limit', i);
+							responseData = await closeApiRequest.call(this, 'GET', '/export/', {}, qs);
+							responseData = responseData.data;
+						}
+					}
+
+					if (operation === 'get') {
+						const exportId = this.getNodeParameter('exportId', i) as string;
+						if (!exportId) {
+							throw new NodeOperationError(this.getNode(), 'Export ID is required');
+						}
+						responseData = await closeApiRequest.call(this, 'GET', `/export/${exportId}/`);
+					}
+
+					if (operation === 'createLead') {
+						const format = this.getNodeParameter('format', i) as string;
+						const exportType = this.getNodeParameter('leadExportType', i) as string;
+						const sQueryRaw = this.getNodeParameter('sQuery', i, '') as unknown;
+						const additional = this.getNodeParameter(
+							'leadExportAdditionalFields',
+							i,
+							{},
+						) as JsonObject;
+
+						const body: JsonObject = { format, type: exportType };
+						try {
+							const sQuery = parseJsonParam(sQueryRaw, 'Search Query');
+							if (sQuery !== undefined) body.s_query = sQuery as JsonObject;
+						} catch (error) {
+							throw new NodeOperationError(this.getNode(), (error as Error).message);
+						}
+						applyExportOptions(body, additional);
+
+						responseData = await closeApiRequest.call(this, 'POST', '/export/lead/', body);
+					}
+
+					if (operation === 'createOpportunity') {
+						const format = this.getNodeParameter('format', i) as string;
+						const paramsRaw = this.getNodeParameter('params', i, '') as unknown;
+						const additional = this.getNodeParameter(
+							'opportunityExportAdditionalFields',
+							i,
+							{},
+						) as JsonObject;
+
+						const body: JsonObject = { format };
+						try {
+							const params = parseJsonParam(paramsRaw, 'Params');
+							if (params !== undefined) body.params = params as JsonObject;
+						} catch (error) {
+							throw new NodeOperationError(this.getNode(), (error as Error).message);
+						}
+						applyExportOptions(body, additional);
+
+						responseData = await closeApiRequest.call(this, 'POST', '/export/opportunity/', body);
+					}
+				}
+
+				// =====================================================================
+				// Field Enrichment (Automation & Bulk Actions)
+				// =====================================================================
+				if (resource === 'fieldEnrichment') {
+					if (operation === 'enrich') {
+						const organizationId = this.getNodeParameter('organizationId', i) as string;
+						const objectType = this.getNodeParameter('objectType', i) as string;
+						const objectId = this.getNodeParameter('objectId', i) as string;
+						const fieldId = this.getNodeParameter('fieldId', i) as string;
+						const additional = this.getNodeParameter('additionalFields', i, {}) as JsonObject;
+
+						if (!organizationId || !objectType || !objectId || !fieldId) {
+							throw new NodeOperationError(
+								this.getNode(),
+								'Organization ID, Object Type, Object ID, and Field ID are required to enrich a field',
+							);
+						}
+
+						const body: JsonObject = {
+							organization_id: organizationId,
+							object_type: objectType,
+							object_id: objectId,
+							field_id: fieldId,
+						};
+
+						if (hasValue(additional.setNewValue)) body.set_new_value = additional.setNewValue;
+						if (hasValue(additional.overwriteExistingValue)) {
+							body.overwrite_existing_value = additional.overwriteExistingValue;
+						}
+
+						responseData = await closeApiRequest.call(this, 'POST', '/enrich_field/', body);
 					}
 				}
 

--- a/nodes/Close/__tests__/Close.node.test.ts
+++ b/nodes/Close/__tests__/Close.node.test.ts
@@ -69,7 +69,16 @@ describe('Close', () => {
 			);
 			expect(resourceProperty).toBeDefined();
 			expect(resourceProperty?.type).toBe('options');
-			expect(resourceProperty?.options).toHaveLength(12);
+			expect(resourceProperty?.options).toHaveLength(16);
+			const resourceValues = resourceProperty?.options?.map((op: any) => op.value);
+			expect(resourceValues).toEqual(
+				expect.arrayContaining([
+					'sequence',
+					'bulkAction',
+					'export',
+					'fieldEnrichment',
+				]),
+			);
 		});
 
 		it('should have all lead operations', () => {
@@ -2996,6 +3005,543 @@ describe('Close', () => {
 					'At least one update field must be provided for bulk update',
 				);
 			});
+		});
+	});
+
+	describe('Sequence Operations', () => {
+		beforeEach(() => {
+			mockExecuteFunctions.getInputData.mockReturnValue([{ json: {} }]);
+		});
+
+		it('should list sequences with a limit', async () => {
+			(closeApiRequest as jest.Mock).mockResolvedValue({
+				data: [{ id: 'seq_1' }, { id: 'seq_2' }],
+				has_more: false,
+			});
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('sequence') // resource
+				.mockReturnValueOnce('find') // operation
+				.mockReturnValueOnce(false) // returnAll
+				.mockReturnValueOnce(25); // limit
+
+			await close.execute.call(mockExecuteFunctions);
+
+			expect(closeApiRequest).toHaveBeenCalledWith('GET', '/sequence/', {}, { _limit: 25 });
+		});
+
+		it('should fetch a single sequence', async () => {
+			(closeApiRequest as jest.Mock).mockResolvedValue({ id: 'seq_abc' });
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('sequence')
+				.mockReturnValueOnce('get')
+				.mockReturnValueOnce('seq_abc');
+
+			await close.execute.call(mockExecuteFunctions);
+
+			expect(closeApiRequest).toHaveBeenCalledWith('GET', '/sequence/seq_abc/');
+		});
+
+		it('should create a sequence parsing JSON schedule and steps', async () => {
+			(closeApiRequest as jest.Mock).mockResolvedValue({ id: 'seq_new' });
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('sequence')
+				.mockReturnValueOnce('create')
+				.mockReturnValueOnce('My Sequence') // name
+				.mockReturnValueOnce('America/Los_Angeles') // timezone
+				.mockReturnValueOnce('{"ranges":[{"weekday":1,"start":"09:00","end":"17:00"}]}')
+				.mockReturnValueOnce(
+					'[{"step_type":"email","delay":0,"required":true,"email_template_id":"tmpl_1"}]',
+				);
+
+			await close.execute.call(mockExecuteFunctions);
+
+			expect(closeApiRequest).toHaveBeenCalledWith('POST', '/sequence/', {
+				name: 'My Sequence',
+				timezone: 'America/Los_Angeles',
+				schedule: { ranges: [{ weekday: 1, start: '09:00', end: '17:00' }] },
+				steps: [
+					{ step_type: 'email', delay: 0, required: true, email_template_id: 'tmpl_1' },
+				],
+			});
+		});
+
+		it('should fail to create a sequence without a name', async () => {
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('sequence')
+				.mockReturnValueOnce('create')
+				.mockReturnValueOnce('') // name
+				.mockReturnValueOnce('UTC')
+				.mockReturnValueOnce('')
+				.mockReturnValueOnce('');
+
+			mockExecuteFunctions.getNode.mockReturnValue({ name: 'Close CRM' } as any);
+
+			await expect(close.execute.call(mockExecuteFunctions)).rejects.toThrow(
+				'Name is required to create a sequence',
+			);
+		});
+
+		it('should fail with a clear message on invalid JSON in schedule', async () => {
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('sequence')
+				.mockReturnValueOnce('create')
+				.mockReturnValueOnce('Sequence')
+				.mockReturnValueOnce('UTC')
+				.mockReturnValueOnce('{not valid json')
+				.mockReturnValueOnce('');
+
+			mockExecuteFunctions.getNode.mockReturnValue({ name: 'Close CRM' } as any);
+
+			await expect(close.execute.call(mockExecuteFunctions)).rejects.toThrow(
+				/Invalid JSON in field "Schedule"/,
+			);
+		});
+
+		it('should update a sequence with partial fields', async () => {
+			(closeApiRequest as jest.Mock).mockResolvedValue({ id: 'seq_abc' });
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('sequence')
+				.mockReturnValueOnce('update')
+				.mockReturnValueOnce('seq_abc')
+				.mockReturnValueOnce({ name: 'Renamed', status: 'paused' });
+
+			await close.execute.call(mockExecuteFunctions);
+
+			expect(closeApiRequest).toHaveBeenCalledWith('PUT', '/sequence/seq_abc/', {
+				name: 'Renamed',
+				status: 'paused',
+			});
+		});
+
+		it('should delete a sequence and return success object', async () => {
+			(closeApiRequest as jest.Mock).mockResolvedValue({});
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('sequence')
+				.mockReturnValueOnce('delete')
+				.mockReturnValueOnce('seq_abc');
+
+			const result = await close.execute.call(mockExecuteFunctions);
+
+			expect(closeApiRequest).toHaveBeenCalledWith('DELETE', '/sequence/seq_abc/');
+			expect(result[0]).toHaveLength(1);
+		});
+
+		it('should subscribe a contact to a sequence', async () => {
+			(closeApiRequest as jest.Mock).mockResolvedValue({ id: 'sub_1' });
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('sequence')
+				.mockReturnValueOnce('subscribe')
+				.mockReturnValueOnce('seq_1') // sequenceId
+				.mockReturnValueOnce('cont_1') // contactId
+				.mockReturnValueOnce('contact@example.com')
+				.mockReturnValueOnce('emailacc_1') // senderAccountId
+				.mockReturnValueOnce('Sales Rep') // senderName
+				.mockReturnValueOnce('rep@example.com')
+				.mockReturnValueOnce({ callsAssignedTo: 'user_1, user_2' });
+
+			await close.execute.call(mockExecuteFunctions);
+
+			expect(closeApiRequest).toHaveBeenCalledWith('POST', '/sequence_subscription/', {
+				sequence_id: 'seq_1',
+				contact_id: 'cont_1',
+				contact_email: 'contact@example.com',
+				sender_account_id: 'emailacc_1',
+				sender_name: 'Sales Rep',
+				sender_email: 'rep@example.com',
+				calls_assigned_to: ['user_1', 'user_2'],
+			});
+		});
+
+		it('should pause a subscription', async () => {
+			(closeApiRequest as jest.Mock).mockResolvedValue({ id: 'sub_1', status: 'paused' });
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('sequence')
+				.mockReturnValueOnce('updateSubscription')
+				.mockReturnValueOnce('sub_1')
+				.mockReturnValueOnce('paused');
+
+			await close.execute.call(mockExecuteFunctions);
+
+			expect(closeApiRequest).toHaveBeenCalledWith('PUT', '/sequence_subscription/sub_1/', {
+				status: 'paused',
+			});
+		});
+
+		it('should require at least one filter to list subscriptions', async () => {
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('sequence')
+				.mockReturnValueOnce('findSubscriptions')
+				.mockReturnValueOnce({}) // filters
+				.mockReturnValueOnce(false); // returnAll
+
+			mockExecuteFunctions.getNode.mockReturnValue({ name: 'Close CRM' } as any);
+
+			await expect(close.execute.call(mockExecuteFunctions)).rejects.toThrow(
+				/At least one of Sequence ID, Contact ID, or Lead ID/,
+			);
+		});
+
+		it('should list subscriptions filtered by sequence', async () => {
+			(closeApiRequest as jest.Mock).mockResolvedValue({ data: [], has_more: false });
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('sequence')
+				.mockReturnValueOnce('findSubscriptions')
+				.mockReturnValueOnce({ sequenceId: 'seq_1' })
+				.mockReturnValueOnce(false)
+				.mockReturnValueOnce(50);
+
+			await close.execute.call(mockExecuteFunctions);
+
+			expect(closeApiRequest).toHaveBeenCalledWith(
+				'GET',
+				'/sequence_subscription/',
+				{},
+				{ sequence_id: 'seq_1', _limit: 50 },
+			);
+		});
+	});
+
+	describe('Bulk Action Operations', () => {
+		beforeEach(() => {
+			mockExecuteFunctions.getInputData.mockReturnValue([{ json: {} }]);
+		});
+
+		it('should send a bulk email', async () => {
+			(closeApiRequest as jest.Mock).mockResolvedValue({ id: 'bulkemail_1' });
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('bulkAction')
+				.mockReturnValueOnce('createEmail')
+				.mockReturnValueOnce('tmpl_1') // templateId
+				.mockReturnValueOnce('emailacc_1') // emailAccountId
+				.mockReturnValueOnce('lead') // contactPreference
+				.mockReturnValueOnce('{"type":"and","queries":[]}')
+				.mockReturnValueOnce({ sendDoneEmail: false, sender: 'sender@example.com' });
+
+			await close.execute.call(mockExecuteFunctions);
+
+			expect(closeApiRequest).toHaveBeenCalledWith('POST', '/bulk_action/email/', {
+				template_id: 'tmpl_1',
+				email_account_id: 'emailacc_1',
+				contact_preference: 'lead',
+				s_query: { type: 'and', queries: [] },
+				sender: 'sender@example.com',
+				send_done_email: false,
+			});
+		});
+
+		it('should require template ID for bulk email', async () => {
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('bulkAction')
+				.mockReturnValueOnce('createEmail')
+				.mockReturnValueOnce('') // templateId missing
+				.mockReturnValueOnce('emailacc_1')
+				.mockReturnValueOnce('lead')
+				.mockReturnValueOnce('{}')
+				.mockReturnValueOnce({});
+
+			mockExecuteFunctions.getNode.mockReturnValue({ name: 'Close CRM' } as any);
+
+			await expect(close.execute.call(mockExecuteFunctions)).rejects.toThrow(
+				/Template ID and Email Account ID/,
+			);
+		});
+
+		it('should bulk edit lead status', async () => {
+			(closeApiRequest as jest.Mock).mockResolvedValue({ id: 'bulkedit_1' });
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('bulkAction')
+				.mockReturnValueOnce('createEdit')
+				.mockReturnValueOnce('set_lead_status') // editType
+				.mockReturnValueOnce('stat_1') // leadStatusId
+				.mockReturnValueOnce('{"type":"and","queries":[]}') // sQuery
+				.mockReturnValueOnce({ sendDoneEmail: true });
+
+			await close.execute.call(mockExecuteFunctions);
+
+			expect(closeApiRequest).toHaveBeenCalledWith('POST', '/bulk_action/edit/', {
+				type: 'set_lead_status',
+				lead_status_id: 'stat_1',
+				s_query: { type: 'and', queries: [] },
+				send_done_email: true,
+			});
+		});
+
+		it('should bulk edit set custom field with operation', async () => {
+			(closeApiRequest as jest.Mock).mockResolvedValue({ id: 'bulkedit_2' });
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('bulkAction')
+				.mockReturnValueOnce('createEdit')
+				.mockReturnValueOnce('set_custom_field')
+				.mockReturnValueOnce('cf_1') // customFieldId
+				.mockReturnValueOnce('new value') // customFieldValue
+				.mockReturnValueOnce('replace') // customFieldOperation
+				.mockReturnValueOnce('{}') // sQuery
+				.mockReturnValueOnce({});
+
+			await close.execute.call(mockExecuteFunctions);
+
+			expect(closeApiRequest).toHaveBeenCalledWith('POST', '/bulk_action/edit/', {
+				type: 'set_custom_field',
+				custom_field_id: 'cf_1',
+				custom_field_value: 'new value',
+				custom_field_operation: 'replace',
+				s_query: {},
+			});
+		});
+
+		it('should require s_query for bulk delete', async () => {
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('bulkAction')
+				.mockReturnValueOnce('createDelete')
+				.mockReturnValueOnce('') // sQuery empty
+				.mockReturnValueOnce({});
+
+			mockExecuteFunctions.getNode.mockReturnValue({ name: 'Close CRM' } as any);
+
+			await expect(close.execute.call(mockExecuteFunctions)).rejects.toThrow(
+				/Search Query \(s_query\) is required for bulk delete/,
+			);
+		});
+
+		it('should bulk delete with s_query', async () => {
+			(closeApiRequest as jest.Mock).mockResolvedValue({ id: 'bulkdel_1' });
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('bulkAction')
+				.mockReturnValueOnce('createDelete')
+				.mockReturnValueOnce('{"type":"and","queries":[{"object_type":"lead"}]}')
+				.mockReturnValueOnce({});
+
+			await close.execute.call(mockExecuteFunctions);
+
+			expect(closeApiRequest).toHaveBeenCalledWith('POST', '/bulk_action/delete/', {
+				s_query: { type: 'and', queries: [{ object_type: 'lead' }] },
+			});
+		});
+
+		it('should run bulk sequence subscription (subscribe)', async () => {
+			(closeApiRequest as jest.Mock).mockResolvedValue({ id: 'bulksub_1' });
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('bulkAction')
+				.mockReturnValueOnce('createSequenceSubscription')
+				.mockReturnValueOnce('subscribe') // sequenceActionType
+				.mockReturnValueOnce('seq_1') // sequenceId
+				.mockReturnValueOnce('emailacc_1')
+				.mockReturnValueOnce('Rep')
+				.mockReturnValueOnce('rep@example.com')
+				.mockReturnValueOnce('lead') // contactPreference
+				.mockReturnValueOnce('{}') // sQuery
+				.mockReturnValueOnce({});
+
+			await close.execute.call(mockExecuteFunctions);
+
+			expect(closeApiRequest).toHaveBeenCalledWith(
+				'POST',
+				'/bulk_action/sequence_subscription/',
+				{
+					action_type: 'subscribe',
+					sequence_id: 'seq_1',
+					sender_account_id: 'emailacc_1',
+					sender_name: 'Rep',
+					sender_email: 'rep@example.com',
+					contact_preference: 'lead',
+					s_query: {},
+				},
+			);
+		});
+
+		it('should run bulk sequence pause without sender fields', async () => {
+			(closeApiRequest as jest.Mock).mockResolvedValue({ id: 'bulksub_2' });
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('bulkAction')
+				.mockReturnValueOnce('createSequenceSubscription')
+				.mockReturnValueOnce('pause')
+				.mockReturnValueOnce('{}') // sQuery
+				.mockReturnValueOnce({});
+
+			await close.execute.call(mockExecuteFunctions);
+
+			expect(closeApiRequest).toHaveBeenCalledWith(
+				'POST',
+				'/bulk_action/sequence_subscription/',
+				{
+					action_type: 'pause',
+					s_query: {},
+				},
+			);
+		});
+
+		it('should fetch a single bulk email by ID', async () => {
+			(closeApiRequest as jest.Mock).mockResolvedValue({ id: 'bulkemail_1' });
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('bulkAction')
+				.mockReturnValueOnce('getEmail')
+				.mockReturnValueOnce('bulkemail_1');
+
+			await close.execute.call(mockExecuteFunctions);
+
+			expect(closeApiRequest).toHaveBeenCalledWith('GET', '/bulk_action/email/bulkemail_1/');
+		});
+
+		it('should list bulk edits with limit', async () => {
+			(closeApiRequest as jest.Mock).mockResolvedValue({ data: [], has_more: false });
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('bulkAction')
+				.mockReturnValueOnce('listEdit')
+				.mockReturnValueOnce(false)
+				.mockReturnValueOnce(10);
+
+			await close.execute.call(mockExecuteFunctions);
+
+			expect(closeApiRequest).toHaveBeenCalledWith('GET', '/bulk_action/edit/', {}, { _limit: 10 });
+		});
+	});
+
+	describe('Export Operations', () => {
+		beforeEach(() => {
+			mockExecuteFunctions.getInputData.mockReturnValue([{ json: {} }]);
+		});
+
+		it('should create a lead export', async () => {
+			(closeApiRequest as jest.Mock).mockResolvedValue({ id: 'export_1', status: 'created' });
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('export')
+				.mockReturnValueOnce('createLead')
+				.mockReturnValueOnce('csv') // format
+				.mockReturnValueOnce('leads') // leadExportType
+				.mockReturnValueOnce('{"type":"and","queries":[]}') // sQuery
+				.mockReturnValueOnce({
+					dateFormat: 'iso8601',
+					fields: 'id, display_name , status_label',
+					includeSmartFields: true,
+					sendDoneEmail: false,
+				});
+
+			await close.execute.call(mockExecuteFunctions);
+
+			expect(closeApiRequest).toHaveBeenCalledWith('POST', '/export/lead/', {
+				format: 'csv',
+				type: 'leads',
+				s_query: { type: 'and', queries: [] },
+				date_format: 'iso8601',
+				fields: ['id', 'display_name', 'status_label'],
+				include_smart_fields: true,
+				send_done_email: false,
+			});
+		});
+
+		it('should create an opportunity export', async () => {
+			(closeApiRequest as jest.Mock).mockResolvedValue({ id: 'export_2' });
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('export')
+				.mockReturnValueOnce('createOpportunity')
+				.mockReturnValueOnce('json')
+				.mockReturnValueOnce('{"status_type":"won"}')
+				.mockReturnValueOnce({ includeAddresses: true, includeCustomObjects: true });
+
+			await close.execute.call(mockExecuteFunctions);
+
+			expect(closeApiRequest).toHaveBeenCalledWith('POST', '/export/opportunity/', {
+				format: 'json',
+				params: { status_type: 'won' },
+				include_addresses: true,
+				include_custom_objects: true,
+			});
+		});
+
+		it('should fetch a single export', async () => {
+			(closeApiRequest as jest.Mock).mockResolvedValue({
+				id: 'export_1',
+				status: 'done',
+				download_url: 'https://example.com/file.csv',
+			});
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('export')
+				.mockReturnValueOnce('get')
+				.mockReturnValueOnce('export_1');
+
+			await close.execute.call(mockExecuteFunctions);
+
+			expect(closeApiRequest).toHaveBeenCalledWith('GET', '/export/export_1/');
+		});
+
+		it('should list exports', async () => {
+			(closeApiRequest as jest.Mock).mockResolvedValue({ data: [], has_more: false });
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('export')
+				.mockReturnValueOnce('find')
+				.mockReturnValueOnce(false)
+				.mockReturnValueOnce(20);
+
+			await close.execute.call(mockExecuteFunctions);
+
+			expect(closeApiRequest).toHaveBeenCalledWith('GET', '/export/', {}, { _limit: 20 });
+		});
+	});
+
+	describe('Field Enrichment Operations', () => {
+		beforeEach(() => {
+			mockExecuteFunctions.getInputData.mockReturnValue([{ json: {} }]);
+		});
+
+		it('should enrich a field on a lead', async () => {
+			(closeApiRequest as jest.Mock).mockResolvedValue({});
+
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('fieldEnrichment')
+				.mockReturnValueOnce('enrich')
+				.mockReturnValueOnce('orga_1')
+				.mockReturnValueOnce('lead')
+				.mockReturnValueOnce('lead_1')
+				.mockReturnValueOnce('cf_1')
+				.mockReturnValueOnce({ setNewValue: true, overwriteExistingValue: true });
+
+			await close.execute.call(mockExecuteFunctions);
+
+			expect(closeApiRequest).toHaveBeenCalledWith('POST', '/enrich_field/', {
+				organization_id: 'orga_1',
+				object_type: 'lead',
+				object_id: 'lead_1',
+				field_id: 'cf_1',
+				set_new_value: true,
+				overwrite_existing_value: true,
+			});
+		});
+
+		it('should require all enrich field IDs', async () => {
+			mockExecuteFunctions.getNodeParameter
+				.mockReturnValueOnce('fieldEnrichment')
+				.mockReturnValueOnce('enrich')
+				.mockReturnValueOnce('') // organizationId missing
+				.mockReturnValueOnce('lead')
+				.mockReturnValueOnce('lead_1')
+				.mockReturnValueOnce('cf_1')
+				.mockReturnValueOnce({});
+
+			mockExecuteFunctions.getNode.mockReturnValue({ name: 'Close CRM' } as any);
+
+			await expect(close.execute.call(mockExecuteFunctions)).rejects.toThrow(
+				/Organization ID, Object Type, Object ID, and Field ID/,
+			);
 		});
 	});
 

--- a/nodes/Close/descriptions/BulkActionDescription.ts
+++ b/nodes/Close/descriptions/BulkActionDescription.ts
@@ -1,0 +1,493 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+export const bulkActionOperations: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+			},
+		},
+		options: [
+			{
+				name: 'Send Bulk Email',
+				value: 'createEmail',
+				description: 'Initiate a new bulk email',
+				action: 'Send a bulk email',
+			},
+			{
+				name: 'List Bulk Emails',
+				value: 'listEmail',
+				description: 'List previously initiated bulk emails',
+				action: 'List bulk emails',
+			},
+			{
+				name: 'Get Bulk Email',
+				value: 'getEmail',
+				description: 'Fetch a single bulk email action',
+				action: 'Get a bulk email',
+			},
+			{
+				name: 'Bulk Edit',
+				value: 'createEdit',
+				description: 'Initiate a new bulk edit action',
+				action: 'Bulk edit leads',
+			},
+			{
+				name: 'List Bulk Edits',
+				value: 'listEdit',
+				description: 'List previously initiated bulk edits',
+				action: 'List bulk edits',
+			},
+			{
+				name: 'Get Bulk Edit',
+				value: 'getEdit',
+				description: 'Fetch a single bulk edit action',
+				action: 'Get a bulk edit',
+			},
+			{
+				name: 'Bulk Delete',
+				value: 'createDelete',
+				description: 'Initiate a new bulk delete action',
+				action: 'Bulk delete leads',
+			},
+			{
+				name: 'List Bulk Deletes',
+				value: 'listDelete',
+				description: 'List previously initiated bulk deletes',
+				action: 'List bulk deletes',
+			},
+			{
+				name: 'Get Bulk Delete',
+				value: 'getDelete',
+				description: 'Fetch a single bulk delete action',
+				action: 'Get a bulk delete',
+			},
+			{
+				name: 'Bulk Sequence Subscription',
+				value: 'createSequenceSubscription',
+				description: 'Initiate a new bulk sequence subscription action',
+				action: 'Run a bulk sequence subscription',
+			},
+			{
+				name: 'List Bulk Sequence Subscriptions',
+				value: 'listSequenceSubscription',
+				description: 'List bulk sequence subscription actions',
+				action: 'List bulk sequence subscriptions',
+			},
+			{
+				name: 'Get Bulk Sequence Subscription',
+				value: 'getSequenceSubscription',
+				description: 'Fetch a single bulk sequence subscription action',
+				action: 'Get a bulk sequence subscription',
+			},
+		],
+		default: 'createEmail',
+	},
+];
+
+const sQueryField: INodeProperties = {
+	displayName: 'Search Query (s_query JSON)',
+	name: 'sQuery',
+	type: 'json',
+	default: '{}',
+	description:
+		'Advanced filtering query object identifying the leads/contacts to act on. See Close Advanced Filtering docs.',
+};
+
+const commonBulkOptions: INodeProperties = {
+	displayName: 'Additional Fields',
+	name: 'additionalFields',
+	type: 'collection',
+	placeholder: 'Add Field',
+	default: {},
+	options: [
+		{
+			displayName: 'Send Done Email',
+			name: 'sendDoneEmail',
+			type: 'boolean',
+			default: true,
+			description: 'Whether to receive a notification email once the bulk action is finished',
+		},
+		{
+			displayName: 'Results Limit',
+			name: 'resultsLimit',
+			type: 'number',
+			typeOptions: { minValue: 1 },
+			default: 0,
+			description: 'Max number of records to process. Leave 0 to disable.',
+		},
+		{
+			displayName: 'Sort (JSON)',
+			name: 'sort',
+			type: 'json',
+			default: '',
+			description: 'Optional array of sort specifications',
+		},
+	],
+};
+
+export const bulkActionFields: INodeProperties[] = [
+	// ----- Get operations: shared ID field -----
+	{
+		displayName: 'Bulk Action ID',
+		name: 'bulkActionId',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['getEmail', 'getEdit', 'getDelete', 'getSequenceSubscription'],
+			},
+		},
+		description: 'The ID of the bulk action to fetch',
+	},
+	// ----- List operations: pagination -----
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['listEmail', 'listEdit', 'listDelete', 'listSequenceSubscription'],
+			},
+		},
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		typeOptions: { minValue: 1 },
+		default: 50,
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['listEmail', 'listEdit', 'listDelete', 'listSequenceSubscription'],
+				returnAll: [false],
+			},
+		},
+		description: 'Max number of results to return',
+	},
+
+	// ===== Bulk Email =====
+	{
+		displayName: 'Template ID',
+		name: 'templateId',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['createEmail'],
+			},
+		},
+		description: 'ID of the email template to send',
+	},
+	{
+		displayName: 'Email Account ID',
+		name: 'emailAccountId',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['createEmail'],
+			},
+		},
+		description: 'ID of the email account used to send the emails',
+	},
+	{
+		displayName: 'Contact Preference',
+		name: 'contactPreference',
+		type: 'options',
+		options: [
+			{ name: 'Lead (Primary Contact Email)', value: 'lead' },
+			{ name: 'Contact (First Email Per Contact)', value: 'contact' },
+		],
+		default: 'lead',
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['createEmail'],
+			},
+		},
+		description: 'Whether to use the primary contact email per lead, or the first email per contact',
+	},
+	{
+		...sQueryField,
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['createEmail'],
+			},
+		},
+	},
+	{
+		...commonBulkOptions,
+		name: 'emailAdditionalFields',
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['createEmail'],
+			},
+		},
+		options: [
+			...((commonBulkOptions.options as INodeProperties[]) ?? []),
+			{
+				displayName: 'Sender',
+				name: 'sender',
+				type: 'string',
+				default: '',
+				description: 'Sender email address override',
+			},
+		],
+	},
+
+	// ===== Bulk Edit =====
+	{
+		displayName: 'Edit Type',
+		name: 'editType',
+		type: 'options',
+		options: [
+			{ name: 'Set Lead Status', value: 'set_lead_status' },
+			{ name: 'Set Custom Field', value: 'set_custom_field' },
+			{ name: 'Clear Custom Field', value: 'clear_custom_field' },
+		],
+		default: 'set_lead_status',
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['createEdit'],
+			},
+		},
+		description: 'The kind of edit to perform on each matching record',
+	},
+	{
+		displayName: 'Lead Status',
+		name: 'leadStatusId',
+		type: 'options',
+		typeOptions: {
+			loadOptionsMethod: 'getLeadStatuses',
+		},
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['createEdit'],
+				editType: ['set_lead_status'],
+			},
+		},
+		description: 'Lead status to assign. Choose from the list, or specify an ID using an <a href="https://docs.n8n.io/code-examples/expressions/">expression</a>.',
+	},
+	{
+		displayName: 'Custom Field ID',
+		name: 'customFieldId',
+		type: 'string',
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['createEdit'],
+				editType: ['set_custom_field', 'clear_custom_field'],
+			},
+		},
+		description: 'ID of the custom field to update',
+	},
+	{
+		displayName: 'Custom Field Value',
+		name: 'customFieldValue',
+		type: 'string',
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['createEdit'],
+				editType: ['set_custom_field'],
+			},
+		},
+		description: 'New value for the custom field. For multi-value fields supply a JSON array.',
+	},
+	{
+		displayName: 'Custom Field Operation',
+		name: 'customFieldOperation',
+		type: 'options',
+		options: [
+			{ name: 'Replace', value: 'replace' },
+			{ name: 'Add', value: 'add' },
+			{ name: 'Remove', value: 'remove' },
+		],
+		default: 'replace',
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['createEdit'],
+				editType: ['set_custom_field'],
+			},
+		},
+		description: 'Operation for multi-value custom fields',
+	},
+	{
+		...sQueryField,
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['createEdit'],
+			},
+		},
+	},
+	{
+		...commonBulkOptions,
+		name: 'editAdditionalFields',
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['createEdit'],
+			},
+		},
+	},
+
+	// ===== Bulk Delete =====
+	{
+		...sQueryField,
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['createDelete'],
+			},
+		},
+	},
+	{
+		...commonBulkOptions,
+		name: 'deleteAdditionalFields',
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['createDelete'],
+			},
+		},
+	},
+
+	// ===== Bulk Sequence Subscription =====
+	{
+		displayName: 'Action Type',
+		name: 'sequenceActionType',
+		type: 'options',
+		options: [
+			{ name: 'Subscribe', value: 'subscribe' },
+			{ name: 'Pause', value: 'pause' },
+			{ name: 'Resume', value: 'resume' },
+			{ name: 'Resume Finished', value: 'resume_finished' },
+		],
+		default: 'subscribe',
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['createSequenceSubscription'],
+			},
+		},
+		description: 'The bulk subscription action to perform',
+	},
+	{
+		displayName: 'Sequence ID',
+		name: 'sequenceId',
+		type: 'string',
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['createSequenceSubscription'],
+				sequenceActionType: ['subscribe'],
+			},
+		},
+		description: 'Required for "subscribe": the sequence to enroll matched contacts in',
+	},
+	{
+		displayName: 'Sender Account ID',
+		name: 'senderAccountId',
+		type: 'string',
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['createSequenceSubscription'],
+				sequenceActionType: ['subscribe'],
+			},
+		},
+		description: 'Required for "subscribe": email account ID used to send the sequence',
+	},
+	{
+		displayName: 'Sender Name',
+		name: 'senderName',
+		type: 'string',
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['createSequenceSubscription'],
+				sequenceActionType: ['subscribe'],
+			},
+		},
+		description: 'Required for "subscribe": display name of the sender',
+	},
+	{
+		displayName: 'Sender Email',
+		name: 'senderEmail',
+		type: 'string',
+		placeholder: 'sender@example.com',
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['createSequenceSubscription'],
+				sequenceActionType: ['subscribe'],
+			},
+		},
+		description: 'Required for "subscribe": email address of the sender',
+	},
+	{
+		displayName: 'Contact Preference',
+		name: 'contactPreference',
+		type: 'options',
+		options: [
+			{ name: 'Lead (Primary Contact Email)', value: 'lead' },
+			{ name: 'Contact (First Email Per Contact)', value: 'contact' },
+		],
+		default: 'lead',
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['createSequenceSubscription'],
+				sequenceActionType: ['subscribe'],
+			},
+		},
+		description: 'Whether to use the primary lead email or per-contact emails',
+	},
+	{
+		...sQueryField,
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['createSequenceSubscription'],
+			},
+		},
+	},
+	{
+		...commonBulkOptions,
+		name: 'sequenceSubscriptionAdditionalFields',
+		displayOptions: {
+			show: {
+				resource: ['bulkAction'],
+				operation: ['createSequenceSubscription'],
+			},
+		},
+	},
+];

--- a/nodes/Close/descriptions/ExportDescription.ts
+++ b/nodes/Close/descriptions/ExportDescription.ts
@@ -1,0 +1,249 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+export const exportOperations: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['export'],
+			},
+		},
+		options: [
+			{
+				name: 'Export Leads',
+				value: 'createLead',
+				description: 'Start a lead export',
+				action: 'Export leads',
+			},
+			{
+				name: 'Export Opportunities',
+				value: 'createOpportunity',
+				description: 'Start an opportunity export',
+				action: 'Export opportunities',
+			},
+			{
+				name: 'Find',
+				value: 'find',
+				description: 'List recent exports',
+				action: 'List exports',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Fetch a single export (use to poll status and retrieve download_url)',
+				action: 'Get an export',
+			},
+		],
+		default: 'createLead',
+	},
+];
+
+const commonExportOptions: INodeProperties[] = [
+	{
+		displayName: 'Date Format',
+		name: 'dateFormat',
+		type: 'options',
+		options: [
+			{ name: 'Original', value: 'original' },
+			{ name: 'ISO 8601', value: 'iso8601' },
+			{ name: 'Excel', value: 'excel' },
+		],
+		default: 'original',
+		description: 'How to format dates in CSV exports',
+	},
+	{
+		displayName: 'Fields (Comma-Separated)',
+		name: 'fields',
+		type: 'string',
+		default: '',
+		description: 'Comma-separated list of fields to include. Leave empty to export all fields.',
+	},
+	{
+		displayName: 'Include Activities',
+		name: 'includeActivities',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to include activities (only with leads + JSON format)',
+	},
+	{
+		displayName: 'Include Smart Fields',
+		name: 'includeSmartFields',
+		type: 'boolean',
+		default: false,
+		description: 'Whether to include calculated/smart fields like email count',
+	},
+	{
+		displayName: 'Send Done Email',
+		name: 'sendDoneEmail',
+		type: 'boolean',
+		default: true,
+		description: 'Whether to receive a notification email once the export is finished',
+	},
+	{
+		displayName: 'Results Limit',
+		name: 'resultsLimit',
+		type: 'number',
+		typeOptions: { minValue: 1 },
+		default: 0,
+		description: 'Max number of records to export. Leave 0 to disable.',
+	},
+];
+
+export const exportFields: INodeProperties[] = [
+	// ----- Get Export -----
+	{
+		displayName: 'Export ID',
+		name: 'exportId',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['export'],
+				operation: ['get'],
+			},
+		},
+		description: 'The ID of the export to fetch',
+	},
+	// ----- List Exports -----
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		displayOptions: {
+			show: {
+				resource: ['export'],
+				operation: ['find'],
+			},
+		},
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		typeOptions: { minValue: 1 },
+		default: 50,
+		displayOptions: {
+			show: {
+				resource: ['export'],
+				operation: ['find'],
+				returnAll: [false],
+			},
+		},
+		description: 'Max number of results to return',
+	},
+
+	// ----- Export Leads -----
+	{
+		displayName: 'Format',
+		name: 'format',
+		type: 'options',
+		options: [
+			{ name: 'CSV', value: 'csv' },
+			{ name: 'JSON', value: 'json' },
+		],
+		default: 'csv',
+		displayOptions: {
+			show: {
+				resource: ['export'],
+				operation: ['createLead', 'createOpportunity'],
+			},
+		},
+		description: 'File format of the exported data',
+	},
+	{
+		displayName: 'Type',
+		name: 'leadExportType',
+		type: 'options',
+		options: [
+			{ name: 'Leads (One Row Per Lead)', value: 'leads' },
+			{ name: 'Contacts (One Row Per Contact)', value: 'contacts' },
+			{ name: 'Lead Opportunities (One Row Per Opportunity)', value: 'lead_opps' },
+		],
+		default: 'leads',
+		displayOptions: {
+			show: {
+				resource: ['export'],
+				operation: ['createLead'],
+			},
+		},
+		description: 'Granularity of the lead export',
+	},
+	{
+		displayName: 'Search Query (s_query JSON)',
+		name: 'sQuery',
+		type: 'json',
+		default: '{}',
+		displayOptions: {
+			show: {
+				resource: ['export'],
+				operation: ['createLead'],
+			},
+		},
+		description: 'Optional advanced filtering query object to narrow exported leads',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'leadExportAdditionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['export'],
+				operation: ['createLead'],
+			},
+		},
+		options: commonExportOptions,
+	},
+
+	// ----- Export Opportunities -----
+	{
+		displayName: 'Params (JSON)',
+		name: 'params',
+		type: 'json',
+		default: '{}',
+		displayOptions: {
+			show: {
+				resource: ['export'],
+				operation: ['createOpportunity'],
+			},
+		},
+		description: 'Optional dictionary of filters used by the /opportunity/ endpoint',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'opportunityExportAdditionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['export'],
+				operation: ['createOpportunity'],
+			},
+		},
+		options: [
+			...commonExportOptions,
+			{
+				displayName: 'Include Addresses',
+				name: 'includeAddresses',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to include addresses in the export',
+			},
+			{
+				displayName: 'Include Custom Objects',
+				name: 'includeCustomObjects',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to include custom objects in the export',
+			},
+		],
+	},
+];

--- a/nodes/Close/descriptions/FieldEnrichmentDescription.ts
+++ b/nodes/Close/descriptions/FieldEnrichmentDescription.ts
@@ -1,0 +1,116 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+export const fieldEnrichmentOperations: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['fieldEnrichment'],
+			},
+		},
+		options: [
+			{
+				name: 'Enrich Field',
+				value: 'enrich',
+				description: 'Use AI to populate a custom field on a lead or contact',
+				action: 'Enrich a field',
+			},
+		],
+		default: 'enrich',
+	},
+];
+
+export const fieldEnrichmentFields: INodeProperties[] = [
+	{
+		displayName: 'Organization ID',
+		name: 'organizationId',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['fieldEnrichment'],
+				operation: ['enrich'],
+			},
+		},
+		description: 'The ID of the organization that owns the target object',
+	},
+	{
+		displayName: 'Object Type',
+		name: 'objectType',
+		type: 'options',
+		options: [
+			{ name: 'Lead', value: 'lead' },
+			{ name: 'Contact', value: 'contact' },
+		],
+		default: 'lead',
+		required: true,
+		displayOptions: {
+			show: {
+				resource: ['fieldEnrichment'],
+				operation: ['enrich'],
+			},
+		},
+		description: 'Type of object to enrich',
+	},
+	{
+		displayName: 'Object ID',
+		name: 'objectId',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['fieldEnrichment'],
+				operation: ['enrich'],
+			},
+		},
+		description: 'The ID of the lead or contact to enrich',
+	},
+	{
+		displayName: 'Field ID',
+		name: 'fieldId',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['fieldEnrichment'],
+				operation: ['enrich'],
+			},
+		},
+		description: 'The ID of the custom field to enrich',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'additionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['fieldEnrichment'],
+				operation: ['enrich'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Set New Value',
+				name: 'setNewValue',
+				type: 'boolean',
+				default: true,
+				description: 'Whether to update the field with the enriched value',
+			},
+			{
+				displayName: 'Overwrite Existing Value',
+				name: 'overwriteExistingValue',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to overwrite the existing field value if one is set',
+			},
+		],
+	},
+];

--- a/nodes/Close/descriptions/SequenceDescription.ts
+++ b/nodes/Close/descriptions/SequenceDescription.ts
@@ -1,0 +1,397 @@
+import type { INodeProperties } from 'n8n-workflow';
+
+export const sequenceOperations: INodeProperties[] = [
+	{
+		displayName: 'Operation',
+		name: 'operation',
+		type: 'options',
+		noDataExpression: true,
+		displayOptions: {
+			show: {
+				resource: ['sequence'],
+			},
+		},
+		options: [
+			{
+				name: 'Create',
+				value: 'create',
+				description: 'Create a new sequence',
+				action: 'Create a sequence',
+			},
+			{
+				name: 'Delete',
+				value: 'delete',
+				description: 'Delete a sequence',
+				action: 'Delete a sequence',
+			},
+			{
+				name: 'Find',
+				value: 'find',
+				description: 'List sequences in the organization',
+				action: 'List sequences',
+			},
+			{
+				name: 'Get',
+				value: 'get',
+				description: 'Fetch a single sequence',
+				action: 'Get a sequence',
+			},
+			{
+				name: 'Get Subscription',
+				value: 'getSubscription',
+				description: 'Fetch a single sequence subscription',
+				action: 'Get a sequence subscription',
+			},
+			{
+				name: 'List Subscriptions',
+				value: 'findSubscriptions',
+				description: 'List sequence subscriptions',
+				action: 'List sequence subscriptions',
+			},
+			{
+				name: 'Subscribe Contact',
+				value: 'subscribe',
+				description: 'Subscribe a contact to a sequence',
+				action: 'Subscribe a contact to a sequence',
+			},
+			{
+				name: 'Update',
+				value: 'update',
+				description: 'Update a sequence',
+				action: 'Update a sequence',
+			},
+			{
+				name: 'Update Subscription',
+				value: 'updateSubscription',
+				description: 'Update a sequence subscription (e.g. pause/resume)',
+				action: 'Update a sequence subscription',
+			},
+		],
+		default: 'find',
+	},
+];
+
+export const sequenceFields: INodeProperties[] = [
+	// ----- Create / Update Sequence -----
+	{
+		displayName: 'Sequence ID',
+		name: 'sequenceId',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['sequence'],
+				operation: ['get', 'update', 'delete'],
+			},
+		},
+		description: 'The ID of the sequence',
+	},
+	{
+		displayName: 'Name',
+		name: 'name',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['sequence'],
+				operation: ['create'],
+			},
+		},
+		description: 'The name of the sequence',
+	},
+	{
+		displayName: 'Timezone',
+		name: 'timezone',
+		type: 'string',
+		default: 'UTC',
+		displayOptions: {
+			show: {
+				resource: ['sequence'],
+				operation: ['create'],
+			},
+		},
+		description: 'IANA timezone for the sequence schedule (e.g. "America/Los_Angeles")',
+	},
+	{
+		displayName: 'Schedule (JSON)',
+		name: 'schedule',
+		type: 'json',
+		default: '{\n  "ranges": [\n    { "weekday": 1, "start": "09:00", "end": "17:00" }\n  ]\n}',
+		displayOptions: {
+			show: {
+				resource: ['sequence'],
+				operation: ['create'],
+			},
+		},
+		description: 'Schedule object defining when the sequence may execute (weekday: 1=Mon..7=Sun)',
+	},
+	{
+		displayName: 'Steps (JSON)',
+		name: 'steps',
+		type: 'json',
+		default: '[\n  {\n    "step_type": "email",\n    "delay": 0,\n    "required": true,\n    "email_template_id": "tmpl_xxx",\n    "threading": "old_thread"\n  }\n]',
+		displayOptions: {
+			show: {
+				resource: ['sequence'],
+				operation: ['create'],
+			},
+		},
+		description: 'Array of step objects (step_type: "email" or "call", delay in seconds, etc.)',
+	},
+	{
+		displayName: 'Update Fields',
+		name: 'updateFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['sequence'],
+				operation: ['update'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Name',
+				name: 'name',
+				type: 'string',
+				default: '',
+				description: 'New name for the sequence',
+			},
+			{
+				displayName: 'Schedule (JSON)',
+				name: 'schedule',
+				type: 'json',
+				default: '',
+				description: 'New schedule object',
+			},
+			{
+				displayName: 'Steps (JSON)',
+				name: 'steps',
+				type: 'json',
+				default: '',
+				description: 'Array of step objects. WARNING: Excluding existing steps will remove them.',
+			},
+			{
+				displayName: 'Status',
+				name: 'status',
+				type: 'options',
+				options: [
+					{ name: 'Active', value: 'active' },
+					{ name: 'Paused', value: 'paused' },
+				],
+				default: 'active',
+				description: 'New status of the sequence',
+			},
+		],
+	},
+	// ----- Find Sequences -----
+	{
+		displayName: 'Return All',
+		name: 'returnAll',
+		type: 'boolean',
+		default: false,
+		displayOptions: {
+			show: {
+				resource: ['sequence'],
+				operation: ['find', 'findSubscriptions'],
+			},
+		},
+		description: 'Whether to return all results or only up to a given limit',
+	},
+	{
+		displayName: 'Limit',
+		name: 'limit',
+		type: 'number',
+		typeOptions: { minValue: 1 },
+		default: 50,
+		displayOptions: {
+			show: {
+				resource: ['sequence'],
+				operation: ['find', 'findSubscriptions'],
+				returnAll: [false],
+			},
+		},
+		description: 'Max number of results to return',
+	},
+	// ----- Subscribe Contact -----
+	{
+		displayName: 'Sequence ID',
+		name: 'sequenceId',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['sequence'],
+				operation: ['subscribe'],
+			},
+		},
+		description: 'The ID of the sequence to subscribe the contact to',
+	},
+	{
+		displayName: 'Contact ID',
+		name: 'contactId',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['sequence'],
+				operation: ['subscribe'],
+			},
+		},
+		description: 'The ID of the contact being subscribed',
+	},
+	{
+		displayName: 'Contact Email',
+		name: 'contactEmail',
+		type: 'string',
+		placeholder: 'name@example.com',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['sequence'],
+				operation: ['subscribe'],
+			},
+		},
+		description: 'Email address of the contact to use for the subscription',
+	},
+	{
+		displayName: 'Sender Account ID',
+		name: 'senderAccountId',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['sequence'],
+				operation: ['subscribe'],
+			},
+		},
+		description: 'Email account ID used as the sender (e.g. emailaccount_xxx)',
+	},
+	{
+		displayName: 'Sender Name',
+		name: 'senderName',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['sequence'],
+				operation: ['subscribe'],
+			},
+		},
+		description: 'Name displayed for the sender',
+	},
+	{
+		displayName: 'Sender Email',
+		name: 'senderEmail',
+		type: 'string',
+		placeholder: 'sender@example.com',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['sequence'],
+				operation: ['subscribe'],
+			},
+		},
+		description: 'Email address of the sender',
+	},
+	{
+		displayName: 'Additional Fields',
+		name: 'subscribeAdditionalFields',
+		type: 'collection',
+		placeholder: 'Add Field',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['sequence'],
+				operation: ['subscribe'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Calls Assigned To',
+				name: 'callsAssignedTo',
+				type: 'string',
+				default: '',
+				description: 'Comma-separated list of user IDs to whom calls should be assigned',
+			},
+		],
+	},
+	// ----- Subscription Get / Update / List -----
+	{
+		displayName: 'Subscription ID',
+		name: 'subscriptionId',
+		type: 'string',
+		required: true,
+		default: '',
+		displayOptions: {
+			show: {
+				resource: ['sequence'],
+				operation: ['getSubscription', 'updateSubscription'],
+			},
+		},
+		description: 'The ID of the sequence subscription',
+	},
+	{
+		displayName: 'Status',
+		name: 'subscriptionStatus',
+		type: 'options',
+		options: [
+			{ name: 'Active', value: 'active' },
+			{ name: 'Paused', value: 'paused' },
+		],
+		default: 'paused',
+		displayOptions: {
+			show: {
+				resource: ['sequence'],
+				operation: ['updateSubscription'],
+			},
+		},
+		description: 'New status for the subscription',
+	},
+	{
+		displayName: 'Subscription Filters',
+		name: 'subscriptionFilters',
+		type: 'collection',
+		placeholder: 'Add Filter',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['sequence'],
+				operation: ['findSubscriptions'],
+			},
+		},
+		description: 'At least one of sequence ID, contact ID, or lead ID must be provided',
+		options: [
+			{
+				displayName: 'Sequence ID',
+				name: 'sequenceId',
+				type: 'string',
+				default: '',
+				description: 'Filter subscriptions by sequence ID',
+			},
+			{
+				displayName: 'Contact ID',
+				name: 'contactId',
+				type: 'string',
+				default: '',
+				description: 'Filter subscriptions by contact ID',
+			},
+			{
+				displayName: 'Lead ID',
+				name: 'leadId',
+				type: 'string',
+				default: '',
+				description: 'Filter subscriptions by lead ID',
+			},
+		],
+	},
+];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-close-crm",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "N8N community node for Close CRM integration with comprehensive lead, opportunity, task, note, call management, and enhanced triggers for workflow automation",
   "keywords": [
     "n8n-community-node-package",


### PR DESCRIPTION
### User-visible impact
The Close CRM node's Resource dropdown gains four new entries, suffixed (Automation & Bulk Actions) to group them visually:
Sequence — list / get / create / update / delete sequences; subscribe a contact to a sequence; get / list / update (pause / resume) sequence subscriptions.
Bulk Action — create / list / get for bulk Email (template-driven sends), bulk Edit (set lead status, set/clear custom fields with replace/add/remove operations), bulk Delete, and bulk Sequence Subscription (subscribe / pause / resume / resume_finished).
Export — start lead exports (leads / contacts / lead_opps) and opportunity exports in CSV or JSON; list exports; fetch a single export so workflows can poll status and read download_url. Exposes date format, fields, smart fields, activities, addresses, and custom-objects flags.
Field Enrichment — AI-enrich a custom field on a lead or contact via POST /enrich_field/, with set_new_value / overwrite_existing_value toggles.
Power-user JSON inputs for s_query, schedule, steps, opportunity export params, and sort make the full Close advanced filtering / scheduling capability available from n8n.
Safety: bulk delete refuses to run without an s_query, so users cannot accidentally target every lead in the org.
Clear error messages: invalid JSON in any JSON-typed field surfaces a Invalid JSON in field "<name>" error pointing at the offending input.
No breaking changes to any existing resource or operation.

### Manual verification performed
npx jest → 194 / 194 tests passing across 4 suites (28 new tests added covering create / list / get / update / delete paths, conditional fields like subscribe vs pause and set_lead_status vs set_custom_field, invalid-JSON handling, missing-required-field guards, and the bulk-delete s_query safety check)
npm run build → success (TypeScript compile + gulp icon build)
Code-level review of every new endpoint against the Close API docs (/sequence/, /sequence_subscription/, /bulk_action/email|edit|delete|sequence_subscription/, /export/lead/, /export/opportunity/, /export/{id}/, /enrich_field/) to confirm HTTP method, path, and request-body field names match.